### PR TITLE
Return validation errors to clients

### DIFF
--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -99,7 +99,7 @@ export class DocumentInvalidError extends DetailedCodedError {
       ErrorCodes.DOCUMENT_INVALID,
       ErrorCodes[ErrorCodes.DOCUMENT_INVALID],
       "Submitted HealthCert is invalid",
-      "The submitted HealthCert has discrepancies in it, \n please contact the HealthCert issuer for clarification."
+      errorMessage
     );
   }
 }

--- a/src/functionHandlers/notarisePdt/handler.ts
+++ b/src/functionHandlers/notarisePdt/handler.ts
@@ -53,13 +53,15 @@ export const main: Handler = async (
     await validateInputs(certificate);
   } catch (e) {
     const errorWithRef = error.extend(`reference:${reference}`);
-    errorWithRef(`Error while validating certificate: ${e.message}`);
+    errorWithRef(
+      `Error while validating certificate: ${e.title}, ${e.messageBody}`
+    );
     return {
       statusCode: 400,
       headers: {
         "x-trace-id": reference
       },
-      body: e.message
+      body: `${e.title}, ${e.messageBody}`
     };
   }
 

--- a/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
+++ b/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
@@ -13,7 +13,10 @@ export const validateDocument = async (
 ) => {
   const results = await verify(attachment, { network: config.network });
   const documentIsValid = isValid(results);
-  if (!documentIsValid) throw new DocumentInvalidError("Invalid document");
+  if (!documentIsValid)
+    throw new DocumentInvalidError(
+      `validation error: ${JSON.stringify(results)}`
+    );
   const identityFragment = results.filter(
     fragment =>
       fragment.status === "VALID" && fragment.type === "ISSUER_IDENTITY"


### PR DESCRIPTION
* [x] Return validation errors to clients for easier debugging. Previously, the only thing that was returned was "validation error" which isn't much to go on for debugging