### PR TITLE
Standardize format of returned errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ When running locally, the required API key will be printed to the console on sta
 
 A response should be returned within 15 seconds.
 
+Possible responses:
+
+* On success, a JSON payload is returned with 3 keys:
+  * `notarisedDocument`: the notarised certificate
+  * `url`: the url where the notarised certificate can be viewed
+  * `ttl`: time to live for the certificate
+* Status code `422` is returned if the JSON is invalid
+* Status code `400` is returned if the payload does not conform to the expected format for a notarised PDT healthcert. If there is additional information available, this is exposed as a JSON object with 3 properties: `title`, `detail` and `code`
+* Status code `500` is returned if the certificate being notarised is valid but there was a problem encountered during the notarisation process.
+
 ---
 
 # Configuration

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -59,14 +59,9 @@ export class DetailedCodedError extends AbstractError {
 
 export enum ErrorCodes {
   // 4xxx invalid requests error
-  MISMATCHING_PARTICULARS = 4001,
   UNRECOGNISED_CLINIC = 4002,
-  TEST_RESULTS_EXPIRED = 4003,
   DOCUMENT_INVALID = 4004,
-  DATA_INVALID = 4005,
-  FILE_TYPE_INVALID = 4006,
-  FILE_INVALID = 4007
-
+  DATA_INVALID = 4005
   // 5xxx internal server error
 }
 
@@ -79,20 +74,8 @@ export class UnrecognisedClinicError extends DetailedCodedError {
       "Unrecognised clinic error",
       ErrorCodes.UNRECOGNISED_CLINIC,
       ErrorCodes[ErrorCodes.UNRECOGNISED_CLINIC],
-      `Submitted HealthCert not from recognised clinic - ${issuerDomain}`,
-      "The HealthCert was not issued by a clinic recognised by the Ministry of Health Singapore"
-    );
-  }
-}
-
-export class TestResultsExpiredError extends DetailedCodedError {
-  constructor() {
-    super(
-      "Expired test results error",
-      ErrorCodes.TEST_RESULTS_EXPIRED,
-      ErrorCodes[ErrorCodes.TEST_RESULTS_EXPIRED],
-      "Submitted HealthCert has expired test results",
-      "The test result is no longer valid. \n The HealthCert needs to be submitted within 72 hours of the test."
+      `HealthCert from unrecognised clinic - ${issuerDomain}`,
+      "The HealthCert submitted was not issued from a domain for a medical facility recognised by the Ministry of Health, Singapore"
     );
   }
 }
@@ -104,7 +87,7 @@ export class DocumentInvalidError extends DetailedCodedError {
       "Invalid document error",
       ErrorCodes.DOCUMENT_INVALID,
       ErrorCodes[ErrorCodes.DOCUMENT_INVALID],
-      "Submitted HealthCert is invalid",
+      "Invalid Document",
       errorMessage
     );
   }
@@ -121,41 +104,10 @@ export class DataInvalidError extends DetailedCodedError {
       "Invalid data error",
       ErrorCodes.DATA_INVALID,
       ErrorCodes[ErrorCodes.DATA_INVALID],
-      "Submitted HealthCert is invalid",
-      `Error reading the following parameters: ${invalidParams.join(", ")}.`
-    );
-  }
-}
-
-export class FileTypeInvalidError extends DetailedCodedError {
-  constructor(invalidType: string) {
-    errorLogger(
-      `FileTypeInvalidError triggered with reason: ${invalidType} file received`
-    );
-    super(
-      "Invalid file type",
-      ErrorCodes.FILE_TYPE_INVALID,
-      ErrorCodes[ErrorCodes.FILE_TYPE_INVALID],
-      "Submitted HealthCert is of the wrong file type",
-      `The file you have attached is an ${invalidType} file.
-Only .oa files can be uploaded at Notarise.
-
-In case you did not already receive this file form the clinic, please contact for the required .oa file.`
-    );
-  }
-}
-
-export class FileInvalidError extends DetailedCodedError {
-  constructor(message: string) {
-    errorLogger(`FileInvalidError triggered with reason: ${message}`);
-    super(
-      "Invalid file",
-      ErrorCodes.FILE_INVALID,
-      ErrorCodes[ErrorCodes.FILE_INVALID],
-      "Submitted HealthCert is invalid",
-      `We noted that there were formatting errors in the submitted .oa file.
-
-Please request for clinic to re-issue the document correctly before submission at Notarise.`
+      "Invalid HealthCert",
+      `There was an error reading the following parameters, that may need to be rectified: ${invalidParams.join(
+        ", "
+      )}.`
     );
   }
 }

--- a/src/functionHandlers/notarisePdt/handler.ts
+++ b/src/functionHandlers/notarisePdt/handler.ts
@@ -67,9 +67,14 @@ export const main: Handler = async (
     return {
       statusCode: 400,
       headers: {
+        "content-type": "application/problem+json",
         "x-trace-id": reference
       },
-      body: `${e.title}, ${e.messageBody}`
+      body: JSON.stringify({
+        code: e.code,
+        title: e.title,
+        detail: e.messageBody
+      })
     };
   }
 

--- a/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
+++ b/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
@@ -15,7 +15,7 @@ export const validateDocument = async (
   const documentIsValid = isValid(results);
   if (!documentIsValid) {
     throw new DocumentInvalidError(
-      `validation error: ${JSON.stringify(results)}`
+      `There was an error verifying the document: ${JSON.stringify(results)}`
     );
   }
   const identityFragment = results.filter(
@@ -24,7 +24,7 @@ export const validateDocument = async (
   );
   if (identityFragment.length !== 1)
     throw new DocumentInvalidError(
-      "Document may only have one issuer identity test"
+      "Document may only have one issuer identity"
     );
   const [issuer] = identityFragment;
   if (!issuer.data || !Array.isArray(issuer.data) || issuer.data.length !== 1)


### PR DESCRIPTION
* [x] Standardize the format of errors returned when the validation of the request fails (i.e, a 400 is returned).
* [x] Clean up unused errors from the code. The invalid file errors were removed because that should only be applicable for use in the formsg handler.

When there is an error validating the request payload, an error is returned in RFC 7807 format:

```
HTTP/1.1 400 Bad Request
content-type: application/problem+json
x-trace-id: aa0f4b0a-713f-4ad0-94fa-eb97be2cb6f2
cache-control: no-cache
content-length: 130
Date: Tue, 23 Mar 2021 06:45:03 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{"code":4005,"title":"Submitted HealthCert is invalid","detail":"Error reading the following parameters: observation references."}
```

This reuses the error codes defined in the formsg handler, which will enable mapping of API-level errors to more user-friendly terminology to communicate them to users. This will be required so that the formsg handler can use this endpoint for notarisation of PDT certs.