### PR TITLE
Obtain FIN (if NRIC is not available) to notify recipient via SPM

### DIFF
--- a/src/functionHandlers/notarisePdt/handler.ts
+++ b/src/functionHandlers/notarisePdt/handler.ts
@@ -97,11 +97,11 @@ export const main: Handler = async (
   if (config.notification.enabled) {
     try {
       const data = getData(certificate);
-      const { nric } = getParticularsFromHealthCert(data);
+      const { nricOrFin } = getParticularsFromHealthCert(data);
       const testData = getTestDataFromHealthCert(data);
       await notifyRecipient({
         url: result.url,
-        nric,
+        nric: nricOrFin,
         passportNumber: testData[0].passportNumber,
         testData,
         validFrom: data.validFrom

--- a/src/functionHandlers/notarisePdt/handler.ts
+++ b/src/functionHandlers/notarisePdt/handler.ts
@@ -97,11 +97,11 @@ export const main: Handler = async (
   if (config.notification.enabled) {
     try {
       const data = getData(certificate);
-      const { nricOrFin } = getParticularsFromHealthCert(data);
+      const { nric, fin } = getParticularsFromHealthCert(data);
       const testData = getTestDataFromHealthCert(data);
       await notifyRecipient({
         url: result.url,
-        nric: nricOrFin,
+        nric: nric || fin,
         passportNumber: testData[0].passportNumber,
         testData,
         validFrom: data.validFrom

--- a/src/models/healthCert.test.ts
+++ b/src/models/healthCert.test.ts
@@ -32,7 +32,8 @@ describe("src/models/healthCert", () => {
       expect(
         getParticularsFromHealthCert(exampleHealthCertWithNric as any)
       ).toStrictEqual({
-        nricOrFin: "S9098989Z",
+        nric: "S9098989Z",
+        fin: undefined,
         passportNumber: "E7831177G"
       });
     });
@@ -40,7 +41,8 @@ describe("src/models/healthCert", () => {
       expect(
         getParticularsFromHealthCert(exampleHealthCertWithoutNric as any)
       ).toStrictEqual({
-        nricOrFin: undefined,
+        nric: undefined,
+        fin: undefined,
         passportNumber: "E7831177G"
       });
     });

--- a/src/models/healthCert.test.ts
+++ b/src/models/healthCert.test.ts
@@ -32,7 +32,7 @@ describe("src/models/healthCert", () => {
       expect(
         getParticularsFromHealthCert(exampleHealthCertWithNric as any)
       ).toStrictEqual({
-        nric: "S9098989Z",
+        nricOrFin: "S9098989Z",
         passportNumber: "E7831177G"
       });
     });
@@ -40,7 +40,7 @@ describe("src/models/healthCert", () => {
       expect(
         getParticularsFromHealthCert(exampleHealthCertWithoutNric as any)
       ).toStrictEqual({
-        nric: undefined,
+        nricOrFin: undefined,
         passportNumber: "E7831177G"
       });
     });

--- a/src/models/healthCert.ts
+++ b/src/models/healthCert.ts
@@ -36,7 +36,7 @@ export const getParticularsFromHealthCert = (document: HealthCertDocument) => {
     identifierEntry => identifierEntry.type === "PPN"
   );
 
-  return { nricOrFin: nric?.value || fin?.value, passportNumber: ppn?.value };
+  return { nric: nric?.value, fin: fin?.value, passportNumber: ppn?.value };
 };
 
 export interface TestData {
@@ -79,9 +79,7 @@ export const getTestDataFromHealthCert = (
     entry => entry.resourceType === "Observation"
   );
 
-  const { passportNumber, nricOrFin: nric } = getParticularsFromHealthCert(
-    document
-  );
+  const { passportNumber, nric } = getParticularsFromHealthCert(document);
 
   const patientName =
     typeof patient?.name?.[0] === "object" ? patient?.name?.[0].text : "";

--- a/src/models/healthCert.ts
+++ b/src/models/healthCert.ts
@@ -25,11 +25,18 @@ export const getParticularsFromHealthCert = (document: HealthCertDocument) => {
       identifierEntry.type instanceof Object &&
       identifierEntry.type.text === "NRIC"
   );
+
+  const fin = patient?.identifier?.find(
+    identifierEntry =>
+      identifierEntry.type instanceof Object &&
+      identifierEntry.type.text === "FIN"
+  );
+
   const ppn = patient?.identifier?.find(
     identifierEntry => identifierEntry.type === "PPN"
   );
 
-  return { nric: nric?.value, passportNumber: ppn?.value };
+  return { nricOrFin: nric?.value || fin?.value, passportNumber: ppn?.value };
 };
 
 export interface TestData {
@@ -72,7 +79,9 @@ export const getTestDataFromHealthCert = (
     entry => entry.resourceType === "Observation"
   );
 
-  const { passportNumber, nric } = getParticularsFromHealthCert(document);
+  const { passportNumber, nricOrFin: nric } = getParticularsFromHealthCert(
+    document
+  );
 
   const patientName =
     typeof patient?.name?.[0] === "object" ? patient?.name?.[0].text : "";


### PR DESCRIPTION
**Context**
SPM notifications are only sent to NRIC holders.

**Proposed changes**
Send SPM notification to FIN holders by attempting to obtain FIN (if NRIC is not available):
```javascript
// ...
return { nricOrFin: nric?.value || fin?.value, ... }
```