### PR TITLE
Upgrade version of @notarise-gov-sg/sns-notify-recipients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@middy/core": "^1.5.2",
         "@middy/http-error-handler": "^1.5.2",
         "@middy/http-json-body-parser": "^1.5.2",
-        "@notarise-gov-sg/sns-notify-recipients": "^0.0.2",
+        "@notarise-gov-sg/sns-notify-recipients": "^0.0.3",
         "aws-sdk": "^2.655.0",
         "aws-xray-sdk-core": "^2.5.0",
         "axios": "^0.19.2",
@@ -6518,9 +6518,10 @@
       }
     },
     "node_modules/@notarise-gov-sg/sns-notify-recipients": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@notarise-gov-sg/sns-notify-recipients/-/sns-notify-recipients-0.0.2.tgz",
-      "integrity": "sha512-QWzJLiUBdQUYGd+0nqRAXetg8SgVrX+rI8lMLQpPTzReiokmxEeXpCxIATmV9KFV3TtD2QPBx1qXyjmIXgWoLw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@notarise-gov-sg/sns-notify-recipients/-/sns-notify-recipients-0.0.3.tgz",
+      "integrity": "sha512-dOeCKphIiRZTy+ZGj0C9zb3eJi+fr18/SrGDk493cYTwA/d5C9wlmyg5fpFqr+lqlX0VxtbJFo254p49QyDN3g==",
+      "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.655.0",
         "aws-xray-sdk-core": "3.2.0",
@@ -35587,9 +35588,9 @@
       }
     },
     "@notarise-gov-sg/sns-notify-recipients": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@notarise-gov-sg/sns-notify-recipients/-/sns-notify-recipients-0.0.2.tgz",
-      "integrity": "sha512-QWzJLiUBdQUYGd+0nqRAXetg8SgVrX+rI8lMLQpPTzReiokmxEeXpCxIATmV9KFV3TtD2QPBx1qXyjmIXgWoLw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@notarise-gov-sg/sns-notify-recipients/-/sns-notify-recipients-0.0.3.tgz",
+      "integrity": "sha512-dOeCKphIiRZTy+ZGj0C9zb3eJi+fr18/SrGDk493cYTwA/d5C9wlmyg5fpFqr+lqlX0VxtbJFo254p49QyDN3g==",
       "requires": {
         "aws-sdk": "^2.655.0",
         "aws-xray-sdk-core": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@middy/core": "^1.5.2",
     "@middy/http-error-handler": "^1.5.2",
     "@middy/http-json-body-parser": "^1.5.2",
-    "@notarise-gov-sg/sns-notify-recipients": "^0.0.2",
+    "@notarise-gov-sg/sns-notify-recipients": "^0.0.3",
     "aws-sdk": "^2.655.0",
     "aws-xray-sdk-core": "^2.5.0",
     "axios": "^0.19.2",


### PR DESCRIPTION
- Bump verison of @notarise-gov-sg/sns-notify-recipients to v0.0.3
- This fixes the bug where the wrong index of `testresult2` was used
- Refer to: https://github.com/Notarise-gov-sg/sns-notify-recipients/pull/3