### PR TITLE
Increase usage limit from 3000 to 10000 per day

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -46,7 +46,7 @@ provider:
     - ${opt:stage, "dev"}-notariseHealthcertKey-Trybe
   usagePlan:
     quota:
-      limit: 3000
+      limit: 10000
       offset: 0
       period: DAY
     throttle:


### PR DESCRIPTION
/CC @ryanoolala 

Providers are reporting 429 errors, they're probably maxing out the 3000 / day allowance.

This MR increases the limit for each provider to 10000 calls per day.