### PR TITLE
chore: revert adding of key as notariseHealthCertKey-notarise already…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -44,7 +44,6 @@ provider:
     - ${opt:stage, "dev"}-notariseHealthcertKey-Nextid
     - ${opt:stage, "dev"}-notariseHealthcertKey-Riverr
     - ${opt:stage, "dev"}-notariseHealthcertKey-Trybe
-    - ${opt:stage, "dev"}-notariseHealthcertKey-GovTech
   usagePlan:
     quota:
       limit: 10000


### PR DESCRIPTION
add govtech apikey for staging 

to be used in conjunction with api-notarise-healthcert-deployment, 

e.g.

```
  e2e-test:
    name: Start E2E test by posting data to stg api gateway
    ....
    - run: npm ci
    # --fail returns an exit code > 0 when the request fails. -- fail sets output to silent, --show-error undoes it.
    - run: |
        curl -vX POST "${{ env.STAGING_BASE_URL }}/notarise/pdt" \
        -d @./mocks/example_healthcert_with_nric_wrapped.json \
        --fail --show-error \
        --header "Content-Type: application/json" \
        --header "x-api-key: ${{ env.X_API_KEY }}" \
      env:
        # notarise heatlhcert stg api
        STAGING_BASE_URL: https://7xq2mf0b9f.execute-api.ap-southeast-1.amazonaws.com/stg
        X_API_KEY: <The generated api key>
```