### PR TITLE
fix: make lab field optional to support pdt art healthcerts

### DIFF
--- a/src/common/healthCertDataValidation.ts
+++ b/src/common/healthCertDataValidation.ts
@@ -19,7 +19,7 @@ const toEnglishWords = (variableName: string): string => {
 // concats all required missing fields of test data to an a string array to be used
 // in the error message
 export const validateHealthCertData = (testDataList: TestData[]) => {
-  const optionalData = ["nric"];
+  const optionalData = ["nric", "lab"];
   const invalidParams: string[] = [];
   testDataList.forEach((testData) => {
     Object.entries(testData).forEach((entry) => {


### PR DESCRIPTION
The `lab` entry is not necessary when endorsing PDT (ART) HealthCerts
```json
# This entry is no longer necessary
{
  "resourceType": "Organization",
  "name": "MacRitchie Laboratory",
  "type": "Accredited Laboratory",
  "contact": {
    "telecom": [
      {
        "system": "phone",
        "value": "+6562711188"
      }
    ],
    "address": {
      "type": "physical",
      "use": "work",
      "text": "2 Thomson Avenue 4 Singapore 098888"
    }
  }
}
```