### PR TITLE
fix: generate wrapped cert script

### DIFF
--- a/scripts/generateInputHealthCert.ts
+++ b/scripts/generateInputHealthCert.ts
@@ -1,5 +1,8 @@
-import { wrapDocument } from "@govtechsg/open-attestation";
-import { signDocument } from "@govtechsg/oa-did-sign";
+import { wrapDocument, v2 } from "@govtechsg/open-attestation";
+import {
+  signDocument,
+  SUPPORTED_SIGNING_ALGORITHM,
+} from "@govtechsg/oa-did-sign";
 import { writeFileSync } from "fs";
 import { config } from "../src/config";
 import sample from "../test/fixtures/example_healthcert_with_nric_unwrapped.json";
@@ -7,11 +10,11 @@ import sample from "../test/fixtures/example_healthcert_with_nric_unwrapped.json
 const OUTPUT_FILE = "test/fixtures/example_healthcert_with_nric_wrapped.json";
 
 const run = async () => {
-  const healthCert = sample as any;
+  const healthCert = sample as v2.OpenAttestationDocument;
   const wrappedHealthCert = wrapDocument(healthCert);
   const signedDocument = await signDocument(
     wrappedHealthCert,
-    "Secp256k1VerificationKey2018",
+    SUPPORTED_SIGNING_ALGORITHM.Secp256k1VerificationKey2018,
     config.didSigner.key,
     config.didSigner.privateKey
   );


### PR DESCRIPTION
Was encountering this error message:

```text
Maximum call stack size exceeded
```