### PR TITLE
179203028: FHIR Parser/Validator for PDT HealthCert Schema v2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25838,6 +25838,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate.js": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.13.1.tgz",
+      "integrity": "sha512-PnFM3xiZ+kYmLyTiMgTYmU7ZHkjBZz2/+F0DaALc/uUtVzdCt1wAosvYJ5hFQi/hz8O4zb52FQhHZRC+uVkJ+g=="
+    },
     "validator": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,16 @@
         "es5-ext": "^0.10.47"
       }
     },
+    "@ahryman40k/ts-fhir-types": {
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.36.tgz",
+      "integrity": "sha512-MuTxKnhpdwh4HEHML+HbZxYKlFdl7ikiTk8o3sDy98cnN2IuNSsodkWMbr6R2qOiTjCPsY5B1vcY6AkH6AY03Q==",
+      "requires": {
+        "fp-ts": "^2.8.3",
+        "io-ts": "^2.0.0",
+        "reflect-metadata": "^0.1.13"
+      }
+    },
     "@arcanis/slice-ansi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@arcanis/slice-ansi/-/slice-ansi-1.0.2.tgz",
@@ -13651,6 +13661,62 @@
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
       "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
     },
+    "fhir": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.9.0.tgz",
+      "integrity": "sha512-x+4LzzcNURfgzTbhDdaLxYNj8L84akM+jVvpuEQNxXggchqH5cPCC1cEWl2PUfJTT/tN8WkhM1tY2xOQI/t/rA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "path": "^0.12.7",
+        "q": "^1.4.1",
+        "randomatic": "^3.1.0",
+        "xml-js": "^1.6.8"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "bundled": true
+        },
+        "path": {
+          "version": "0.12.7",
+          "bundled": true,
+          "requires": {
+            "process": "^0.11.1",
+            "util": "^0.10.3"
+          }
+        },
+        "process": {
+          "version": "0.11.10",
+          "bundled": true
+        },
+        "q": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "util": {
+          "version": "0.10.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "xml-js": {
+          "version": "1.6.8",
+          "bundled": true,
+          "requires": {
+            "sax": "^1.2.4"
+          }
+        }
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -13962,6 +14028,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fp-ts": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.1.tgz",
+      "integrity": "sha512-CJOfs+Heq/erkE5mqH2mhpsxCKABGmcLyeEwPxtbTlkLkItGUs6bmk2WqjB2SgoVwNwzTE5iKjPQJiq06CPs5g=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -14970,6 +15041,11 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "io-ts": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.16.tgz",
+      "integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -18442,6 +18518,11 @@
         "json-buffer": "3.0.0"
       }
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -19144,6 +19225,11 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
       }
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -21082,6 +21168,23 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
       "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        }
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -21342,6 +21445,11 @@
       "requires": {
         "resolve": "^1.1.6"
       }
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "serverless-offline-ses": "https://github.com/rjchow/serverless-offline-ses/tarball/release/1",
     "serverless-vpc-discovery": "^3.0.0",
     "url-join": "^4.0.1",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "validate.js": "^0.13.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@ahryman40k/ts-fhir-types": "^4.0.36",
     "@govtechsg/oa-did-sign": "^2.2.0",
     "@govtechsg/oa-schemata": "^1.11.2",
     "@govtechsg/oa-verify": "^7.4.4",
@@ -37,6 +38,7 @@
     "aws-xray-sdk-core": "^3.3.3",
     "axios": "^0.21.1",
     "debug": "^4.3.2",
+    "fhir": "^4.9.0",
     "file-loader": "^6.2.0",
     "he": "1.2.0",
     "http-errors": "1.8.0",

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -1,0 +1,7 @@
+import { R4 } from "@ahryman40k/ts-fhir-types";
+
+import pcr from "../test/fixtures/v2/pcr-unwrapped.json";
+import { parse } from "../src/models/fhir/parse";
+
+const parsed = parse("PCR", pcr.fhirBundle as R4.IBundle);
+console.log(parsed);

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -8,4 +8,4 @@ const parsed = fhirHelper.parse(sample.fhirBundle as R4.IBundle);
 fhirHelper.hasRequiredFields("PCR", parsed);
 
 // eslint-disable-next-line no-console
-console.log(parsed);
+console.log(JSON.stringify(parsed, null, 2));

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -1,7 +1,7 @@
 import { R4 } from "@ahryman40k/ts-fhir-types";
 
 import pcr from "../test/fixtures/v2/pcr-unwrapped.json";
-import { parse } from "../src/models/fhir/parse";
+import fhir from "../src/models/fhir";
 
-const parsed = parse("PCR", pcr.fhirBundle as R4.IBundle);
+const parsed = fhir.parse("PCR", pcr.fhirBundle as R4.IBundle);
 console.log(parsed);

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -1,8 +1,8 @@
 import { R4 } from "@ahryman40k/ts-fhir-types";
 
-import pcr from "../test/fixtures/v2/pcr-unwrapped.json";
+import sample from "../test/fixtures/v2/pcr-unwrapped.json";
 import fhir from "../src/models/fhir";
 
-const parsed = fhir.parse("PCR", pcr.fhirBundle as R4.IBundle);
+const parsed = fhir.parse(sample.fhirBundle as R4.IBundle);
 // eslint-disable-next-line no-console
 console.log(parsed);

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -4,4 +4,5 @@ import pcr from "../test/fixtures/v2/pcr-unwrapped.json";
 import fhir from "../src/models/fhir";
 
 const parsed = fhir.parse("PCR", pcr.fhirBundle as R4.IBundle);
+// eslint-disable-next-line no-console
 console.log(parsed);

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -1,8 +1,10 @@
 import { R4 } from "@ahryman40k/ts-fhir-types";
 
 import sample from "../test/fixtures/v2/pcr-unwrapped.json";
+// import sample from "../test/fixtures/v2/art-unwrapped.json";
 import fhir from "../src/models/fhir";
 
 const parsed = fhir.parse(sample.fhirBundle as R4.IBundle);
+
 // eslint-disable-next-line no-console
 console.log(parsed);

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -5,6 +5,7 @@ import sample from "../test/fixtures/v2/pcr-unwrapped.json";
 import fhirHelper from "../src/models/fhir";
 
 const parsed = fhirHelper.parse(sample.fhirBundle as R4.IBundle);
+fhirHelper.hasRequiredFields("PCR", parsed);
 
 // eslint-disable-next-line no-console
 console.log(parsed);

--- a/scripts/temp.ts
+++ b/scripts/temp.ts
@@ -2,9 +2,9 @@ import { R4 } from "@ahryman40k/ts-fhir-types";
 
 import sample from "../test/fixtures/v2/pcr-unwrapped.json";
 // import sample from "../test/fixtures/v2/art-unwrapped.json";
-import fhir from "../src/models/fhir";
+import fhirHelper from "../src/models/fhir";
 
-const parsed = fhir.parse(sample.fhirBundle as R4.IBundle);
+const parsed = fhirHelper.parse(sample.fhirBundle as R4.IBundle);
 
 // eslint-disable-next-line no-console
 console.log(parsed);

--- a/src/models/fhir/index.ts
+++ b/src/models/fhir/index.ts
@@ -1,3 +1,4 @@
 import { parse } from "./parse";
+import { hasRequiredFields } from "./required";
 
-export default { parse };
+export default { parse, hasRequiredFields };

--- a/src/models/fhir/index.ts
+++ b/src/models/fhir/index.ts
@@ -1,0 +1,3 @@
+import { parse } from "./parse";
+
+export default { parse };

--- a/src/models/fhir/parse.ts
+++ b/src/models/fhir/parse.ts
@@ -161,7 +161,7 @@ export const parse = (fhirBundle: R4.IBundle): Bundle => {
     specimen,
     observations,
     practitioner,
-    organisation: { moh, lhp, al },
+    organization: { moh, lhp, al },
     device,
   };
 };

--- a/src/models/fhir/parse.ts
+++ b/src/models/fhir/parse.ts
@@ -1,5 +1,6 @@
 import { R4 } from "@ahryman40k/ts-fhir-types";
 import {
+  Bundle,
   Patient,
   Specimen,
   Observation,
@@ -100,7 +101,7 @@ const parsers = (resource: R4.IResourceList | undefined) => {
  * @param fhirBundle Raw FHIR Bundle resource
  * @returns An object containing all the parsed resources in the bundle (simplified)
  */
-export const parse = (fhirBundle: R4.IBundle) => {
+export const parse = (fhirBundle: R4.IBundle): Bundle => {
   //  0. Bundle resource
   parsers(fhirBundle);
 

--- a/src/models/fhir/parse.ts
+++ b/src/models/fhir/parse.ts
@@ -1,0 +1,132 @@
+import { R4 } from "@ahryman40k/ts-fhir-types";
+import {
+  Patient,
+  Specimen,
+  Observation,
+  Practitioner,
+  Organization,
+} from "./types";
+
+const Fhir = require("fhir").Fhir;
+const fhir = new Fhir();
+
+export const parse = (type: "PCR" | "ART", fhirBundle: R4.IBundle) => {
+  //  0. Bundle resource
+  parsers(fhirBundle);
+
+  // 1. Patient resource
+  const fhirPatient = fhirBundle.entry?.find(
+    (entry) => entry.resource?.resourceType === "Patient"
+  )?.resource;
+  const patient = parsers(fhirPatient) as Patient;
+
+  // 2. Specimen resource
+  const fhirSpecimen = fhirBundle.entry?.find(
+    (entry) => entry.resource?.resourceType === "Specimen"
+  )?.resource;
+  const specimen = parsers(fhirSpecimen) as Specimen;
+
+  // 3. Observation resource(s)
+  const observations = fhirBundle.entry
+    ?.filter((entry) => entry.resource?.resourceType === "Observation")
+    ?.map((o) => parsers(o.resource) as Observation)!;
+
+  // 4. Practitioner resource
+  const fhirPractitioner = fhirBundle.entry?.find(
+    (entry) => entry.fullUrl === observations?.[0].practitionerResourceUuid
+  )?.resource;
+  const practitioner = parsers(fhirPractitioner) as Practitioner;
+
+  // 5. Organization (MOH) resource
+  const fhirOrganizationMoh = fhirBundle.entry?.find(
+    (entry) => entry.fullUrl === practitioner.organizationResourceUuid
+  )?.resource;
+  const moh = parsers(fhirOrganizationMoh) as Organization;
+
+  // 6. Organization (Licensed Healthcare Provider) resource
+  const fhirOrganizationLhp = fhirBundle.entry?.find(
+    (entry) =>
+      entry.resource?.resourceType === "Organization" &&
+      entry.resource?.type?.[0].text === "Licensed Healthcare Provider"
+  )?.resource;
+  const lhp = parsers(fhirOrganizationLhp) as Organization;
+
+  // 7. Organization (Accredited Laboratory) resource
+  const fhirOrganizationAl = fhirBundle.entry?.find(
+    (entry) =>
+      entry.resource?.resourceType === "Organization" &&
+      entry.resource?.type?.[0].text === "Accredited Laboratory"
+  )?.resource;
+  const al = parsers(fhirOrganizationAl) as Organization; // Only for PCR
+
+  return {
+    patient,
+    specimen,
+    observations,
+    practitioner,
+    organisation: { moh, lhp, al },
+  };
+};
+
+const parsers = (resource: R4.IResourceList | undefined) => {
+  /* Validate resource against FHIR base spec */
+  const validator = fhir.validate(resource, { errorOnUnexpected: true });
+  if (!validator.valid) {
+    throw new Error(JSON.stringify(validator.messages));
+  }
+
+  switch (resource?.resourceType) {
+    case "Bundle":
+      return resource;
+
+    case "Patient":
+      return {
+        fullName: resource.name?.[0].text,
+        gender: resource.gender,
+        birthDate: resource.birthDate,
+        nationality: resource.extension?.[0].extension?.find(
+          (e) => e.url === "code"
+        )?.valueCodeableConcept?.coding?.[0],
+        passportNumber: resource.identifier?.find((i) => i.id === "PPN")?.value,
+        nricFin: resource.identifier?.find((i) => i.id === "NRIC-FIN")?.value,
+      } as Patient;
+
+    case "Specimen":
+      return {
+        swabType: resource.type?.coding?.[0],
+        collectionDateTime: resource.collection?.collectedDateTime,
+        // deviceResourceUuid: resource.subject?.reference, // Only for ART
+      } as Specimen;
+
+    case "Observation":
+      return {
+        practitionerResourceUuid: resource.performer?.[0].reference,
+        acsn: resource.identifier?.find((i) => i.id === "ACSN")?.value,
+        targetDisease: resource.category?.[0].coding?.[0],
+        result: resource.valueCodeableConcept?.coding?.[0],
+        effectiveDateTime: resource.effectiveDateTime,
+        status: resource.status,
+      } as Observation;
+
+    case "Practitioner":
+      return {
+        fullName: resource.name?.[0].text,
+        mcr: resource.qualification?.[0].identifier?.find((i) => i.id === "MCR")
+          ?.value,
+        organizationResourceUuid: resource.qualification?.[0].issuer?.reference,
+      } as Practitioner;
+
+    case "Organization":
+      return {
+        fullName: resource.name,
+        type: resource.type?.[0].coding?.[0],
+        url: resource.contact?.[0].telecom?.find((t) => t.system === "url")
+          ?.value,
+        phone: resource.contact?.[0].telecom?.find((t) => t.system === "phone")
+          ?.value,
+        address: resource.contact?.[0].address,
+      } as Organization;
+    default:
+      throw new Error(`Unable to find an appropriate parser for: ${resource}`);
+  }
+};

--- a/src/models/fhir/parse.ts
+++ b/src/models/fhir/parse.ts
@@ -12,8 +12,14 @@ const { Fhir } = require("fhir");
 
 const fhir = new Fhir();
 
+/**
+ * The mapping definition of each FHIR resource.
+ *
+ * Note: This function will ONLY validate a resource against FHIR base spec.
+ * @param resource Raw FHIR resource
+ * @returns Parsed FHIR resource (simplified)
+ */
 const parsers = (resource: R4.IResourceList | undefined) => {
-  /* Validate resource against FHIR base spec */
   const validator = fhir.validate(resource, { errorOnUnexpected: true });
   if (!validator.valid) {
     throw new Error(JSON.stringify(validator.messages));
@@ -75,7 +81,13 @@ const parsers = (resource: R4.IResourceList | undefined) => {
   }
 };
 
-export const parse = (type: "PCR" | "ART", fhirBundle: R4.IBundle) => {
+/**
+ * Parses a Bundle of resources into a simplified format.
+ *
+ * @param fhirBundle Raw FHIR Bundle resource
+ * @returns An object containing all the parsed resources in the bundle (simplified)
+ */
+export const parse = (fhirBundle: R4.IBundle) => {
   //  0. Bundle resource
   parsers(fhirBundle);
 

--- a/src/models/fhir/parse.ts
+++ b/src/models/fhir/parse.ts
@@ -21,7 +21,7 @@ const fhir = new Fhir();
  * @returns Parsed FHIR resource (simplified)
  */
 const parsers = (resource: R4.IResourceList | undefined) => {
-  if (!resource) return; // Skip parsing an undefined resource
+  if (!resource) return undefined; // Skip parsing an undefined resource
 
   const validator = fhir.validate(resource, { errorOnUnexpected: true });
   if (!validator.valid) {
@@ -32,7 +32,7 @@ const parsers = (resource: R4.IResourceList | undefined) => {
     );
   }
 
-  switch (resource?.resourceType) {
+  switch (resource.resourceType) {
     case "Bundle":
       return resource;
 

--- a/src/models/fhir/required.ts
+++ b/src/models/fhir/required.ts
@@ -1,0 +1,48 @@
+import validate from "validate.js";
+import { Bundle } from "./types";
+
+const commonConstraints = {
+  "patient.fullName": { presence: true },
+  "patient.birthDate": { presence: true },
+  "patient.nationality.code": { presence: true },
+  "patient.passportNumber": { presence: true },
+
+  "specimen.swabType.code": { presence: true },
+  "specimen.collectionDateTime": { presence: true },
+
+  // TODO: Finish up the rest of the constraints
+};
+
+const artConstraints = {
+  // TODO: Finish up the rest of the constraints
+  // Fields only ART HealthCerts should have
+};
+
+const pcrConstraints = {
+  // TODO: Finish up the rest of the constraints
+  // Fields only PCR HealthCerts should have
+};
+
+export const hasRequiredFields = (type: "ART" | "PCR", bundle: Bundle) => {
+  let constraints;
+
+  switch (type) {
+    case "ART":
+      constraints = { ...commonConstraints, ...artConstraints };
+      break;
+
+    case "PCR":
+      constraints = { ...commonConstraints, ...pcrConstraints };
+      break;
+
+    default:
+      throw new Error(
+        `Unable to check for required fields of unknown type: ${type}`
+      );
+  }
+
+  const errors = validate(bundle, constraints);
+  if (errors) {
+    throw new Error(JSON.stringify(errors));
+  }
+};

--- a/src/models/fhir/types.ts
+++ b/src/models/fhir/types.ts
@@ -52,6 +52,6 @@ export interface Bundle {
   specimen: Specimen;
   observations: Observation[];
   practitioner: Practitioner;
-  organisation: { moh: Organization; lhp: Organization; al?: Organization };
+  organization: { moh: Organization; lhp: Organization; al?: Organization };
   device?: Device;
 }

--- a/src/models/fhir/types.ts
+++ b/src/models/fhir/types.ts
@@ -42,3 +42,7 @@ export interface Organization {
     text: string;
   };
 }
+
+export interface Device {
+  type: R4.ICoding;
+}

--- a/src/models/fhir/types.ts
+++ b/src/models/fhir/types.ts
@@ -46,3 +46,12 @@ export interface Organization {
 export interface Device {
   type: R4.ICoding;
 }
+
+export interface Bundle {
+  patient: Patient;
+  specimen: Specimen;
+  observations: Observation[];
+  practitioner: Practitioner;
+  organisation: { moh: Organization; lhp: Organization; al?: Organization };
+  device?: Device;
+}

--- a/src/models/fhir/types.ts
+++ b/src/models/fhir/types.ts
@@ -1,0 +1,44 @@
+import { R4 } from "@ahryman40k/ts-fhir-types";
+
+export interface Patient {
+  fullName: string;
+  gender?: R4.PatientGenderKind;
+  birthDate: string;
+  nationality: R4.ICoding;
+  passportNumber: string;
+  nricFin?: string;
+}
+
+export interface Specimen {
+  deviceResourceUuid?: string;
+  swabType: R4.ICoding;
+  collectionDateTime: string;
+}
+
+export interface Observation {
+  practitionerResourceUuid: string;
+  acsn: string;
+  targetDisease: R4.ICoding;
+  testType: R4.ICoding;
+  result: R4.ICoding;
+  effectiveDateTime: string;
+  status: R4.ObservationStatusKind;
+}
+
+export interface Practitioner {
+  fullName: string;
+  mcr: string;
+  organizationResourceUuid: string;
+}
+
+export interface Organization {
+  fullName: string;
+  type: R4.ICoding;
+  url: string;
+  phone: string;
+  address: {
+    type: R4.AddressTypeKind;
+    use: R4.AddressUseKind;
+    text: string;
+  };
+}

--- a/src/models/fhir/types.ts
+++ b/src/models/fhir/types.ts
@@ -17,6 +17,8 @@ export interface Specimen {
 
 export interface Observation {
   practitionerResourceUuid: string;
+  organizationLhpResourceUuid: string;
+  organizationAlResourceUuid?: string;
   acsn: string;
   targetDisease: R4.ICoding;
   testType: R4.ICoding;
@@ -28,7 +30,7 @@ export interface Observation {
 export interface Practitioner {
   fullName: string;
   mcr: string;
-  organizationResourceUuid: string;
+  organizationMohResourceUuid: string;
 }
 
 export interface Organization {
@@ -47,11 +49,16 @@ export interface Device {
   type: R4.ICoding;
 }
 
+export interface GroupedObservation {
+  observation: Observation;
+  practitioner: Practitioner;
+  organization: { lhp: Organization; al?: Organization };
+}
+
 export interface Bundle {
   patient: Patient;
   specimen: Specimen;
-  observations: Observation[];
-  practitioner: Practitioner;
-  organization: { moh: Organization; lhp: Organization; al?: Organization };
+  observations: GroupedObservation[];
+  organization: { moh: Organization };
   device?: Device;
 }

--- a/test/fixtures/v2/art-unwrapped.json
+++ b/test/fixtures/v2/art-unwrapped.json
@@ -89,6 +89,11 @@
             {
               "type": "Practitioner",
               "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+            },
+            {
+              "id": "LHP",
+              "type": "Organization",
+              "reference": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1"
             }
           ],
           "identifier": [

--- a/test/fixtures/v2/art-unwrapped.json
+++ b/test/fixtures/v2/art-unwrapped.json
@@ -1,0 +1,255 @@
+{
+  "id": "340139b0-8e92-4ed6-a589-d54730f52963",
+  "version": "pdt-healthcert-v2.0",
+  "type": "ART",
+  "validFrom": "2021-05-18T06:43:12.152Z",
+  "fhirVersion": "4.0.1",
+  "fhirBundle": {
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
+        "resource": {
+          "resourceType": "Patient",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-nationality",
+              "extension": [
+                {
+                  "url": "code",
+                  "valueCodeableConcept": {
+                    "text": "Patient Nationality",
+                    "coding": [
+                      {
+                        "system": "urn:iso:std:iso:3166",
+                        "code": "SG"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "identifier": [
+            {
+              "id": "PPN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "PPN",
+                    "display": "Passport Number"
+                  }
+                ]
+              },
+              "value": "E7831177G"
+            },
+            {
+              "id": "NRIC-FIN",
+              "value": "S9098989Z"
+            }
+          ],
+          "name": [
+            {
+              "text": "Tan Chen Chen"
+            }
+          ],
+          "gender": "female",
+          "birthDate": "1990-01-15"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
+        "resource": {
+          "resourceType": "Specimen",
+          "subject": {
+            "type": "Device",
+            "reference": "urn:uuid:9103a5c8-5957-40f5-85a1-e6633e890777"
+          },
+          "type": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "258500001",
+                "display": "Nasopharyngeal swab"
+              }
+            ]
+          },
+          "collection": {
+            "collectedDateTime": "2020-09-27T06:15:00Z"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
+        "resource": {
+          "resourceType": "Observation",
+          "performer": [
+            {
+              "type": "Practitioner",
+              "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+            }
+          ],
+          "identifier": [
+            {
+              "id": "ACSN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "ACSN",
+                    "display": "Accession ID"
+                  }
+                ]
+              },
+              "value": "123456789"
+            }
+          ],
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "840539006",
+                  "display": "COVID-19"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "94531-1",
+                "display": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"
+              }
+            ]
+          },
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative"
+              }
+            ]
+          },
+          "effectiveDateTime": "2020-09-28T06:15:00Z",
+          "status": "final"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
+        "resource": {
+          "resourceType": "Practitioner",
+          "name": [{ "text": "Dr Michael Lim" }],
+          "qualification": [
+            {
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "MCR",
+                    "display": "Practitioner Medicare number"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "id": "MCR",
+                  "value": "123456"
+                }
+              ],
+              "issuer": {
+                "type": "Organization",
+                "reference": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "Ministry of Health (MOH)",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "govt",
+                  "display": "Government"
+                }
+              ]
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                { "system": "url", "value": "https://www.moh.gov.sg" },
+                { "system": "phone", "value": "+6563259220" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Medical Clinic",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Licensed Healthcare Provider"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                {
+                  "system": "url",
+                  "value": "https://www.macritchieclinic.com.sg"
+                },
+                { "system": "phone", "value": "+6561234567" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "MacRitchie Hospital, Thomson Road, Singapore 123000"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:9103a5c8-5957-40f5-85a1-e6633e890777",
+        "resource": {
+          "resourceType": "Device",
+          "type": {
+            "coding": [
+              {
+                "system": "https://covid-19-diagnostics.jrc.ec.europa.eu/devices",
+                "code": "1232",
+                "display": "Abbott Rapid Diagnostics, Panbio COVID-19 Ag Rapid Test"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/v2/pcr-unwrapped.json
+++ b/test/fixtures/v2/pcr-unwrapped.json
@@ -1,0 +1,271 @@
+{
+  "id": "76caf3f9-5591-4ef1-b756-1cb47a76dede",
+  "version": "pdt-healthcert-v2.0",
+  "type": "PCR",
+  "validFrom": "2021-08-16T08:56:36.881Z",
+  "fhirVersion": "4.0.1",
+  "fhirBundle": {
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
+        "resource": {
+          "resourceType": "Patient",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-nationality",
+              "extension": [
+                {
+                  "url": "code",
+                  "valueCodeableConcept": {
+                    "text": "Patient Nationality",
+                    "coding": [
+                      {
+                        "system": "urn:iso:std:iso:3166",
+                        "code": "SG"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "identifier": [
+            {
+              "id": "PPN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "PPN",
+                    "display": "Passport Number"
+                  }
+                ]
+              },
+              "value": "E7831177G"
+            },
+            {
+              "id": "NRIC-FIN",
+              "value": "S9098989Z"
+            }
+          ],
+          "name": [
+            {
+              "text": "Tan Chen Chen"
+            }
+          ],
+          "gender": "female",
+          "birthDate": "1990-01-15"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
+        "resource": {
+          "resourceType": "Specimen",
+          "type": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "258500001",
+                "display": "Nasopharyngeal swab"
+              }
+            ]
+          },
+          "collection": {
+            "collectedDateTime": "2020-09-27T06:15:00Z"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
+        "resource": {
+          "resourceType": "Observation",
+          "performer": [
+            {
+              "type": "Practitioner",
+              "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+            }
+          ],
+          "identifier": [
+            {
+              "id": "ACSN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "ACSN",
+                    "display": "Accession ID"
+                  }
+                ]
+              },
+              "value": "123456789"
+            }
+          ],
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "840539006",
+                  "display": "COVID-19"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "94531-1",
+                "display": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"
+              }
+            ]
+          },
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative"
+              }
+            ]
+          },
+          "effectiveDateTime": "2020-09-28T06:15:00Z",
+          "status": "final"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
+        "resource": {
+          "resourceType": "Practitioner",
+          "name": [{ "text": "Dr Michael Lim" }],
+          "qualification": [
+            {
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "MCR",
+                    "display": "Practitioner Medicare number"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "id": "MCR",
+                  "value": "123456"
+                }
+              ],
+              "issuer": {
+                "type": "Organization",
+                "reference": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "Ministry of Health (MOH)",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "govt",
+                  "display": "Government"
+                }
+              ]
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                { "system": "url", "value": "https://www.moh.gov.sg" },
+                { "system": "phone", "value": "+6563259220" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Medical Clinic",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Licensed Healthcare Provider"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                {
+                  "system": "url",
+                  "value": "https://www.macritchieclinic.com.sg"
+                },
+                { "system": "phone", "value": "+6561234567" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "MacRitchie Hospital, Thomson Road, Singapore 123000"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:839a7c54-6b40-41cb-b10d-9295d7e75f77",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Laboratory",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Accredited Laboratory"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                {
+                  "system": "url",
+                  "value": "https://www.macritchielaboratory.com.sg"
+                },
+                { "system": "phone", "value": "+6567654321" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "2 Thomson Avenue 4, Singapore 098888"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/v2/pcr-unwrapped.json
+++ b/test/fixtures/v2/pcr-unwrapped.json
@@ -85,6 +85,16 @@
             {
               "type": "Practitioner",
               "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+            },
+            {
+              "id": "LHP",
+              "type": "Organization",
+              "reference": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1"
+            },
+            {
+              "id": "AL",
+              "type": "Organization",
+              "reference": "urn:uuid:839a7c54-6b40-41cb-b10d-9295d7e75f77"
             }
           ],
           "identifier": [


### PR DESCRIPTION
Mappings are provided here: https://github.com/Open-Attestation/schemata/pull/38

- [x] FHIR parser by @HJunyuan: Validate against FHIR base spec and extract fields from FHIR resources.
- [ ] Required fields checker by @zawmyolatt: Ensure the required fields for Notarise are present. If not, throw errors.

Essentially, it should do something like:
```javascript
/* 1. FHIR parser */
parsed = fhirHelper.parse(fhirBundle as R4.IBundle);

/* 2. Required fields checker */
fhirHelper.hasRequiredFields("PCR", parsed); // throws errors[] if invalid
```

To test it, simply run:
```bash
$ npm i
$ npx ts-node scripts/temp.ts
```