### PR TITLE
feat: generate urls with key in anchor

### DIFF
--- a/src/services/transientStorage/index.ts
+++ b/src/services/transientStorage/index.ts
@@ -28,7 +28,7 @@ const { endpoint, apiKey } = config.transientStorage;
 // type FailureResponse = Runtype<typeof SuccessfulResponseDef>;
 // type Response = Runtype<typeof ResponseDef>;
 
-const stringifyAndEncode = (obj: object): string =>
+const stringifyAndEncode = (obj: any): string =>
   encodeURIComponent(JSON.stringify(obj));
 
 const universalUrl = (url: string, key: string) => {

--- a/src/services/transientStorage/index.ts
+++ b/src/services/transientStorage/index.ts
@@ -28,19 +28,20 @@ const { endpoint, apiKey } = config.transientStorage;
 // type FailureResponse = Runtype<typeof SuccessfulResponseDef>;
 // type Response = Runtype<typeof ResponseDef>;
 
+const stringifyAndEncode = (obj: object): string =>
+  encodeURIComponent(JSON.stringify(obj));
+
 const universalUrl = (url: string, key: string) => {
-  const query = encodeURIComponent(
-    JSON.stringify({
-      type: "DOCUMENT",
-      payload: {
-        uri: url,
-        key,
-        permittedActions: ["VIEW", "STORE"],
-        redirect: "https://www.verify.gov.sg/verify",
-      },
-    })
-  );
-  return `https://action.openattestation.com/?q=${query}`;
+  const query = stringifyAndEncode({
+    type: "DOCUMENT",
+    payload: {
+      uri: url,
+      permittedActions: ["VIEW", "STORE"],
+      redirect: "https://www.verify.gov.sg/verify",
+    },
+  });
+  const anchor = key ? `#${stringifyAndEncode({ key })}` : ``;
+  return `https://action.openattestation.com/?q=${query}${anchor}`;
 };
 
 export const buildStoredUrl = (id: string, key: string) => {


### PR DESCRIPTION
As Verify.gov.sg (https://github.com/Open-Attestation/verify.gov.sg/pull/78) is now updated to obtain the key from the anchor, the generated URLs in Notarise should follow the new format.