### PR TITLE
Chore: 180045605 remove loading public/private keys value from ssm direct

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5080,6 +5080,21 @@
         "@middy/util": "^2.5.1"
       }
     },
+    "@middy/ssm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@middy/ssm/-/ssm-2.5.2.tgz",
+      "integrity": "sha512-NG9F/RgRQGdTNluPt0HK3MA0ZmqHu1yFhqqjbxQC5cY3dK1xrZ7nfxo4PItpJ6SjQFaOfeVT4KFg9zOp+ptAhA==",
+      "requires": {
+        "@middy/util": "^2.5.2"
+      },
+      "dependencies": {
+        "@middy/util": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@middy/util/-/util-2.5.2.tgz",
+          "integrity": "sha512-dFvCbWqxpjtBCOTTguTSLCJC5FwoIC125G9f+Nl+4hAXwV2sNwZ7g0GH3T6MIvxjkHeqFYMxUm3ePjGTEYyxGg=="
+        }
+      }
+    },
     "@middy/util": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@middy/core": "^2.5.1",
     "@middy/http-error-handler": "^2.5.1",
     "@middy/http-json-body-parser": "^2.5.1",
+    "@middy/ssm": "^2.5.2",
     "@notarise-gov-sg/gpay-covid-cards": "^1.0.2",
     "@notarise-gov-sg/i18n-nationality": "^1.2.2",
     "@notarise-gov-sg/sns-notify-recipients": "^1.3.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,9 +27,13 @@ provider:
     - Effect: Allow
       Action: ["kms:GenerateDataKey"]
       Resource: "arn:aws:kms:${self:provider.region}:${self:custom.accountId}:key/${env:SNS_KMS_KEY_ID, 'PLACEHOLDER'}"
-    - Effect: Allow
-      Action: ["ssm:GetParameter"]
-      Resource: "arn:aws:ssm:${self:provider.region}:${self:custom.accountId}:parameter/serverless/api-notarise-healthcerts/GPAY_COVID_CARD_PRIVATE_KEY"
+    - Effect: "Allow"
+      Action:
+        - ssm:GetParameters
+      Resource:
+        - "arn:aws:ssm:${self:provider.region}:${self:custom.accountId}:parameter/serverless/SIGNING_EU_QR_PRIVATE_KEY"
+        - "arn:aws:ssm:${self:provider.region}:${self:custom.accountId}:parameter/serverless/SIGNING_EU_QR_PUBLIC_KEY"
+        - "arn:aws:ssm:${self:provider.region}:${self:custom.accountId}:parameter/serverless/api-notarise-healthcerts/GPAY_COVID_CARD_PRIVATE_KEY"
     - Effect: Allow
       Action: ["sns:Publish"]
       Resource: "arn:aws:sns:${self:provider.region}:${self:custom.accountId}:healthcert"
@@ -195,8 +199,6 @@ custom:
     GPAY_COVID_CARD_ISSUER: ${ssm:/serverless/api-notarise-healthcerts/GPAY_COVID_CARD_ISSUER, ""}
     GPAY_COVID_CARD_ISSUER_ID: ${ssm:/serverless/api-notarise-healthcerts/GPAY_COVID_CARD_ISSUER_ID, ""}
     SIGNING_EU_QR_NAME: ${ssm:/serverless/api-notarise-healthcerts/SIGNING_EU_QR_NAME, ""}
-    SIGNING_EU_QR_PUBLIC_KEY: ${ssm:/serverless/SIGNING_EU_QR_PUBLIC_KEY, ""}
-    SIGNING_EU_QR_PRIVATE_KEY: ${ssm:/serverless/SIGNING_EU_QR_PRIVATE_KEY~true, ""}
     HEALTH_CERT_NOTIFICATION_ENABLED: ${ssm:/serverless/api-notarise-healthcerts/HEALTH_CERT_NOTIFICATION_ENABLED, ""}
     HEALTH_CERT_NOTIFICATION_TOPIC_ARN: ${ssm:/serverless/api-notarise-healthcerts/HEALTH_CERT_NOTIFICATION_TOPIC_ARN, ""}
   dotenv:

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,7 @@ const getEuSigner = () => ({
   ),
 });
 
-const getGPayCovidCardSigner = async () => ({
+const getGPayCovidCardSigner = () => ({
   issuer: getDefaultIfUndefined(
     process.env.GPAY_COVID_CARD_ISSUER,
     "notarise-gpay-stg@gvt0048-gcp-233-notarise-pd.iam.gserviceaccount.com" // Staging Issuer
@@ -67,7 +67,7 @@ const generateConfig = () => ({
   authorizedIssuers: getAuthorizedIssuersApiConfig(),
   didSigner: getDidSigner(),
   euSigner: getEuSigner(),
-  gpaySigner: getGPayCovidCardSigner,
+  gpaySigner: getGPayCovidCardSigner(),
   env: process.env.NODE_ENV,
   network: getDefaultIfUndefined(process.env.ETHEREUM_NETWORK, "ropsten"),
   isValidationEnabled: !(

--- a/src/functionHandlers/middyfy.ts
+++ b/src/functionHandlers/middyfy.ts
@@ -4,9 +4,11 @@ import jsonBodyParser from "@middy/http-json-body-parser";
 import httpErrorHandler from "@middy/http-error-handler";
 import { cloudWatchMiddleware } from "../middleware/cloudWatch";
 import { validateSchemaMiddleware } from "../middleware/validateSchema";
+import { withSsm } from "../middleware/withSsm";
 
 export const middyfy = (handler: Handler) =>
   middy(handler).use([
+    withSsm,
     jsonBodyParser(),
     validateSchemaMiddleware(),
     cloudWatchMiddleware(),

--- a/src/functionHandlers/notarisePdt/v2/handler.ts
+++ b/src/functionHandlers/notarisePdt/v2/handler.ts
@@ -195,9 +195,8 @@ export const main: Handler = async (
   /* Generate Google Pay COVID Card URL (Only if enabled) */
   if (config.isGPayCovidCardEnabled) {
     try {
-      const gpaySigner = await config.gpaySigner();
       result.gpayCovidCardUrl = genGPayCovidCardUrl(
-        gpaySigner,
+        config.gpaySigner,
         parsedFhirBundle,
         reference,
         result.url

--- a/src/middleware/withSsm.ts
+++ b/src/middleware/withSsm.ts
@@ -1,0 +1,38 @@
+import ssm from "@middy/ssm";
+
+export declare type ISSMOptions = {
+  fetchData?: { [key: string]: string };
+  disablePrefetch?: boolean;
+  cacheKey?: string;
+  cacheExpiry?: number;
+  setToEnv?: boolean;
+  setToContext?: boolean;
+};
+
+const ssmOptions: ISSMOptions = {
+  fetchData: {
+    SIGNING_EU_QR_PRIVATE_KEY: "/serverless/SIGNING_EU_QR_PRIVATE_KEY",
+    SIGNING_EU_QR_PUBLIC_KEY: "/serverless/SIGNING_EU_QR_PUBLIC_KEY",
+    GPAY_COVID_CARD_PRIVATE_KEY:
+      "/serverless/api-notarise-healthcerts/GPAY_COVID_CARD_PRIVATE_KEY",
+  },
+  cacheExpiry: 15 * 60 * 1000, // set 15 mins cache
+  cacheKey: "ssm-cache-secrets",
+  setToEnv: true,
+};
+
+const ssmInstance = () => {
+  if (
+    process.env.NODE_ENV === "development" ||
+    process.env.NODE_ENV === "test"
+  ) {
+    return {
+      before: async (): Promise<void> => {
+        // skip middleware logic
+      },
+    };
+  }
+  return ssm(ssmOptions);
+};
+
+export const withSsm = ssmInstance();

--- a/src/models/euHealthCert/createEuHealthCert/createEuSignedTestQr.ts
+++ b/src/models/euHealthCert/createEuHealthCert/createEuSignedTestQr.ts
@@ -1,18 +1,26 @@
 import { signAndPack, makeCWT } from "@pathcheck/dcc-sdk";
 import { notarise } from "@govtechsg/oa-schemata";
 import { EuHealthCert } from "../../../types";
-import { config } from "../../../config";
+import { config, getDefaultIfUndefined } from "../../../config";
 
 const { euSigner } = config;
 
 export const createEuSignedTestQr = async (euHealthCerts: EuHealthCert[]) => {
+  const publicKey = getDefaultIfUndefined(
+    process.env.SIGNING_EU_QR_PUBLIC_KEY,
+    ""
+  ).replace(/\\n/g, "\n");
+  const privateKey = getDefaultIfUndefined(
+    process.env.SIGNING_EU_QR_PRIVATE_KEY,
+    ""
+  ).replace(/\\n/g, "\n");
   const testHealthCertsQr: notarise.SignedEuHealthCert[] = [];
   await Promise.all(
     euHealthCerts.map(async (euHealthCert) => {
       const qrData = await signAndPack(
         await makeCWT(euHealthCert, null, euSigner.name),
-        euSigner.publicKey,
-        euSigner.privateKey
+        publicKey,
+        privateKey
       );
       const testType =
         euHealthCert.t[0].tt === "LP6464-4"

--- a/src/models/gpayCovidCard/index.ts
+++ b/src/models/gpayCovidCard/index.ts
@@ -5,14 +5,19 @@ import GPay, {
 } from "@notarise-gov-sg/gpay-covid-cards";
 import { Bundle } from "../../models/fhir/types";
 import { isoToDateOnlyString, isoToLocaleString } from "../../common/datetime";
+import { getDefaultIfUndefined } from "../../config";
 
 const genGPayCovidCardUrl = (
-  gpaySigner: { issuer: string; issuerId: string; privateKey: string },
+  gpaySigner: { issuer: string; issuerId: string },
   parsedFhirBundle: Bundle,
   uuid: string,
   storedUrl: string
 ) => {
-  const gpay = GPay(gpaySigner.privateKey);
+  const privateKey = getDefaultIfUndefined(
+    process.env.GPAY_COVID_CARD_PRIVATE_KEY,
+    ""
+  ).replace(/\\n/g, "\n");
+  const gpay = GPay(privateKey);
 
   const patientDetails: PatientDetails = {
     dateOfBirth: isoToDateOnlyString(parsedFhirBundle.patient.birthDate),


### PR DESCRIPTION
**What does this PR do?**
- remove ssm direct load config variable from `serverless.yml`
- add `@middy/ssm` package
- add 15 mins cache ssm middleware
- load `SIGNING_EU_QR_PUBLIC_KEY`, `SIGNING_EU_QR_PRIVATE_KEY` and `GPAY_COVID_CARD_PRIVATE_KEY` variables from env using 15 mins ssm cache middleware