### PR TITLE
180023434: improve error message when validating fhir bundle

### DIFF
--- a/src/functionHandlers/notarisePdt/v2/handler.ts
+++ b/src/functionHandlers/notarisePdt/v2/handler.ts
@@ -8,7 +8,7 @@ import {
 import { R4 } from "@ahryman40k/ts-fhir-types";
 import { notarise } from "@govtechsg/oa-schemata";
 import fhirHelper from "../../../models/fhir";
-import { Bundle } from "../../../models/fhir/types";
+import { ParsedBundle } from "../../../models/fhir/types";
 import { getTestDataFromParseFhirBundle } from "../../../models/healthCertV2";
 import { getLogger } from "../../../common/logger";
 import { DetailedCodedError } from "../../../common/error";
@@ -40,7 +40,7 @@ const { trace, error } = getLogger(
 export const notarisePdt = async (
   reference: string,
   certificate: WrappedDocument<PDTHealthCertV2Document>,
-  parsedFhirBundle: Bundle,
+  parsedFhirBundle: ParsedBundle,
   testData: TestData[]
 ): Promise<{ result: NotarisationResult; directUrl: string }> => {
   const errorWithRef = trace.extend(`reference:${reference}`);
@@ -103,7 +103,7 @@ export const main: Handler = async (
   const errorWithRef = error.extend(`reference:${reference}`);
 
   /* 1. Validation */
-  let parsedFhirBundle: Bundle;
+  let parsedFhirBundle: ParsedBundle;
   let data: PDTHealthCertV2Document; // The unwrapped document
   let testData: TestData[];
   try {
@@ -143,7 +143,7 @@ export const main: Handler = async (
     ({ result, directUrl } = await notarisePdt(
       reference,
       wrappedDocument,
-      parsedFhirBundle as Bundle,
+      parsedFhirBundle as ParsedBundle,
       testData as TestData[]
     ));
   } catch (e) {

--- a/src/middleware/cloudWatch.ts
+++ b/src/middleware/cloudWatch.ts
@@ -9,7 +9,7 @@ import {
   Observation,
   PDTHealthCertV2Document,
 } from "../types";
-import { Observation as ObservationV2 } from "../models/fhir/types";
+import { ParsedObservation as ObservationV2 } from "../models/fhir/types";
 import { parsers } from "../models/fhir/parse";
 import { logError, trace } from "./trace";
 

--- a/src/models/fhir/constraints.ts
+++ b/src/models/fhir/constraints.ts
@@ -1,0 +1,236 @@
+import _ from "lodash";
+import { pdtHealthCertV2 } from "@govtechsg/oa-schemata";
+import { DocumentInvalidError } from "../../common/error";
+
+/**
+ * Common constraints required by all types of HealthCerts:
+ * To convert parsed format -> original FHIR Bundle format (to aid in custom error message)
+ */
+const commonConstraints = {
+  // Patient
+  "patient.fullName": "Patient.name[0].text",
+  "patient.birthDate": "Patient.birthDate",
+
+  "patient.nationality.system":
+    "Patient.extension[0].extension[url=code].valueCodeableConcept.coding[0].system",
+  "patient.nationality.code":
+    "Patient.extension[0].extension[url=code].valueCodeableConcept.coding[0].code",
+
+  "patient.passportNumber": "Patient.identifier[0].{ id=PPN, type, value }",
+
+  // Organization (MOH)
+  "organization.moh.fullName": "Organization.name",
+
+  "organization.moh.type.system": "Organization.type[0].coding[0].system",
+  "organization.moh.type.code": "Organization.type[0].coding[0].code",
+  "organization.moh.type.display": "Organization.type[0].coding[0].display",
+
+  "organization.moh.url":
+    "Organization.contact[0].telecom[0].{ system=url, value }",
+  "organization.moh.phone":
+    "Organization.contact[0].telecom[1].{ system=phone, value }",
+
+  "organization.moh.address.type": "Organization.contact[0].address.type",
+  "organization.moh.address.use": "Organization.contact[0].address.use",
+  "organization.moh.address.text": "Organization.contact[0].address.text",
+};
+
+/**
+ * Common grouped constraints required by all types of HealthCerts:
+ * To convert parsed format -> original FHIR Bundle format (to aid in custom error message)
+ */
+const commonGroupedConstraints = {
+  // Observation(s)
+  "observations._.observation.specimenResourceUuid":
+    "_.Observation.specimen.{ type=Specimen, reference }",
+  "observations._.observation.practitionerResourceUuid":
+    "_.Observation.performer[0].{ type=Practitioner, reference }",
+  "observations._.observation.organizationLhpResourceUuid":
+    "_.Observation.performer[1].{ id=LHP, type=Organization, reference }",
+
+  "observations._.observation.acsn": "_.Observation.identifier[id=ACSN].value",
+
+  "observations._.observation.targetDisease.system":
+    "_.Observation.category[0].coding[0].system",
+  "observations._.observation.targetDisease.code":
+    "_.Observation.category[0].coding[0].code",
+  "observations._.observation.targetDisease.display":
+    "_.Observation.category[0].coding[0].display",
+
+  "observations._.observation.testType.system":
+    "_.Observation.code.coding[0].system",
+  "observations._.observation.testType.code":
+    "_.Observation.code.coding[0].code",
+  "observations._.observation.testType.display":
+    "_.Observation.code.coding[0].display",
+
+  "observations._.observation.result.system":
+    "_.Observation.valueCodeableConcept.coding[0].system",
+  "observations._.observation.result.code":
+    "_.Observation.valueCodeableConcept.coding[0].code",
+  "observations._.observation.result.display":
+    "_.Observation.valueCodeableConcept.coding[0].display",
+
+  "observations._.observation.effectiveDateTime":
+    "_.Observation.effectiveDateTime",
+  "observations._.observation.status": "",
+
+  // Specimen(s)
+  "observations._.specimen.swabType.system": "_.Specimen.type.coding[0].system",
+  "observations._.specimen.swabType.code": "_.Specimen.type.coding[0].code",
+  "observations._.specimen.swabType.display":
+    "_.Specimen.type.coding[0].display",
+
+  "observations._.specimen.collectionDateTime":
+    "_.Specimen.collection.collectedDateTime",
+
+  // Practitioner(s)
+  "observations._.practitioner.fullName": "_.Practitioner.name[0].text",
+  "observations._.practitioner.mcr":
+    "_.Practitioner.qualification[0].identifier[0].{ id=MCR, value }",
+  "observations._.practitioner.organizationMohResourceUuid":
+    "_.Practitioner.qualification[0].issuer.{ type=Organization, reference }",
+
+  // Organization(s) (LHP)
+  "observations._.organization.lhp.fullName": "_.Organization.name",
+
+  "observations._.organization.lhp.type.system":
+    "_.Organization.type[0].coding[0].system",
+  "observations._.organization.lhp.type.code":
+    "_.Organization.type[0].coding[0].code",
+  "observations._.organization.lhp.type.display":
+    "_.Organization.type[0].coding[0].display",
+
+  "observations._.organization.lhp.url":
+    "_.Organization.contact[0].telecom[0].{ system=url, value }",
+  "observations._.organization.lhp.phone":
+    "_.Organization.contact[0].telecom[1].{ system=phone, value }",
+
+  "observations._.organization.lhp.address.type":
+    "_.Organization.contact[0].address.type",
+  "observations._.organization.lhp.address.use":
+    "_.Organization.contact[0].address.use",
+  "observations._.organization.lhp.address.text":
+    "_.Organization.contact[0].address.text",
+};
+
+/**
+ * ART constraints:
+ * To convert parsed format -> original FHIR Bundle format (to aid in custom error message)
+ */
+const artGroupedConstraints = {
+  // Specimen(s)
+  "observations._.specimen.deviceResourceUuid":
+    "_.Specimen.subject.{ type=Device, reference }",
+
+  // Device(s)
+  "observations._.device.type.system": "_.Device.type.coding[0].system",
+  "observations._.device.type.code": "_.Device.type.coding[0].code",
+  "observations._.device.type.display": "_.Device.type.coding[0].display",
+};
+
+/**
+ * PCR constraints:
+ * To convert parsed format -> original FHIR Bundle format (to aid in custom error message)
+ */
+const pcrGroupedConstraints = {
+  // Observation(s)
+  "observations._.observation.organizationAlResourceUuid":
+    "Observation.performer[2].{ id=AL, type=Organization, reference }",
+
+  // Organization(s) (AL)
+  "observations._.organization.al.fullName": "_.Organization.name",
+
+  "observations._.organization.al.type.system":
+    "_.Organization.type[0].coding[0].system",
+  "observations._.organization.al.type.code":
+    "_.Organization.type[0].coding[0].code",
+  "observations._.organization.al.type.display":
+    "_.Organization.type[0].coding[0].display",
+
+  "observations._.organization.al.url":
+    "_.Organization.contact[0].telecom[0].{ system=url, value }",
+  "observations._.organization.al.phone":
+    "_.Organization.contact[0].telecom[1].{ system=phone, value }",
+
+  "observations._.organization.al.address.type":
+    "_.Organization.contact[0].address.type",
+  "observations._.organization.al.address.use":
+    "_.Organization.contact[0].address.use",
+  "observations._.organization.al.address.text":
+    "_.Organization.contact[0].address.text",
+};
+
+const generateConstraints = (constraintMapping: Record<string, string>) => {
+  const allKeys = Object.keys(constraintMapping);
+  const constraints: Record<string, any> = {};
+
+  allKeys.forEach((k) => {
+    constraints[k] = {
+      presence: {
+        message: `'${constraintMapping[k]}' is required`,
+        allowEmpty: false,
+      },
+    };
+  });
+
+  return constraints;
+};
+
+const generateGroupedConstraints = (
+  constraintMapping: Record<string, string>,
+  observationCount: number
+) => {
+  const allKeys = Object.keys(constraintMapping);
+  const constraints: Record<string, any> = {};
+
+  for (let i = 0; i < observationCount; i += 1) {
+    allKeys.forEach((k) => {
+      const key = k.replace("_", i.toString());
+      const message = constraintMapping[k].replace("_", i.toString());
+      constraints[key] = {
+        presence: { message: `'${message}' is required`, allowEmpty: false },
+      };
+    });
+  }
+
+  return constraints;
+};
+
+export type Type = pdtHealthCertV2.PdtTypes | pdtHealthCertV2.PdtTypes[];
+export const getConstraints = (type: Type, observationCount: number) => {
+  const { PdtTypes } = pdtHealthCertV2;
+
+  const supportedMultiType = [PdtTypes.Pcr, PdtTypes.Ser]; // For now, only ["PCR", "SER"] is supported
+  const isValidMultiType = _.isEqual(
+    _.sortBy(supportedMultiType),
+    _.sortBy(type)
+  );
+
+  if (type === PdtTypes.Art) {
+    // ART HealthCert
+    return {
+      ...generateConstraints(commonConstraints),
+      ...generateGroupedConstraints(commonGroupedConstraints, observationCount),
+      ...generateGroupedConstraints(artGroupedConstraints, observationCount),
+    };
+  } else if (
+    type === PdtTypes.Pcr ||
+    type === PdtTypes.Ser ||
+    isValidMultiType
+  ) {
+    // PCR, SER or PCR + SER HealthCert
+    // Currently PCR and SER have the same validation constraint
+    return {
+      ...generateConstraints(commonConstraints),
+      ...generateGroupedConstraints(commonGroupedConstraints, observationCount),
+      ...generateGroupedConstraints(pcrGroupedConstraints, observationCount),
+    };
+  } else {
+    throw new DocumentInvalidError(
+      `Notarise does not support endorsement of this HealthCert Type: ${JSON.stringify(
+        type
+      )}`
+    );
+  }
+};

--- a/src/models/fhir/parse.ts
+++ b/src/models/fhir/parse.ts
@@ -1,13 +1,13 @@
 import { R4 } from "@ahryman40k/ts-fhir-types";
 import {
-  Bundle,
-  Patient,
-  Specimen,
-  Observation,
-  Practitioner,
-  Organization,
+  ParsedBundle,
+  ParsedPatient,
+  ParsedSpecimen,
+  ParsedObservation,
+  ParsedPractitioner,
+  ParsedOrganization,
   GroupedObservation,
-  Device,
+  ParsedDevice,
 } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -48,14 +48,14 @@ export const parsers = (resource: R4.IResourceList | undefined) => {
         )?.valueCodeableConcept?.coding?.[0],
         passportNumber: resource.identifier?.find((i) => i.id === "PPN")?.value,
         nricFin: resource.identifier?.find((i) => i.id === "NRIC-FIN")?.value,
-      } as Patient;
+      } as ParsedPatient;
 
     case "Specimen":
       return {
         swabType: resource.type?.coding?.[0],
         collectionDateTime: resource.collection?.collectedDateTime,
         deviceResourceUuid: resource.subject?.reference, // Only for ART
-      } as Specimen;
+      } as ParsedSpecimen;
 
     case "Observation":
       return {
@@ -75,7 +75,7 @@ export const parsers = (resource: R4.IResourceList | undefined) => {
         result: resource.valueCodeableConcept?.coding?.[0],
         effectiveDateTime: resource.effectiveDateTime,
         status: resource.status,
-      } as Observation;
+      } as ParsedObservation;
 
     case "Practitioner":
       return {
@@ -84,7 +84,7 @@ export const parsers = (resource: R4.IResourceList | undefined) => {
           ?.value,
         organizationMohResourceUuid:
           resource.qualification?.[0].issuer?.reference,
-      } as Practitioner;
+      } as ParsedPractitioner;
 
     case "Organization":
       return {
@@ -95,12 +95,12 @@ export const parsers = (resource: R4.IResourceList | undefined) => {
         phone: resource.contact?.[0].telecom?.find((t) => t.system === "phone")
           ?.value,
         address: resource.contact?.[0].address,
-      } as Organization;
+      } as ParsedOrganization;
 
     case "Device":
       return {
         type: resource.type?.coding?.[0],
-      } as Device;
+      } as ParsedDevice;
 
     default:
       throw new Error(`Unable to find an appropriate parser for: ${resource}`);
@@ -113,7 +113,7 @@ export const parsers = (resource: R4.IResourceList | undefined) => {
  * @param fhirBundle Raw FHIR Bundle resource
  * @returns An object containing all the parsed resources in the bundle (simplified)
  */
-export const parse = (fhirBundle: R4.IBundle): Bundle => {
+export const parse = (fhirBundle: R4.IBundle): ParsedBundle => {
   //  0. Bundle resource
   parsers(fhirBundle);
 
@@ -121,43 +121,43 @@ export const parse = (fhirBundle: R4.IBundle): Bundle => {
   const fhirPatient = fhirBundle.entry?.find(
     (entry) => entry.resource?.resourceType === "Patient"
   )?.resource;
-  const patient = parsers(fhirPatient) as Patient;
+  const patient = parsers(fhirPatient) as ParsedPatient;
 
   // 2. Observation resource(s)
   const observations = fhirBundle.entry
     ?.filter((entry) => entry.resource?.resourceType === "Observation")
     ?.map((o) => {
-      const observation = parsers(o.resource) as Observation;
+      const observation = parsers(o.resource) as ParsedObservation;
 
       // 2a. Specimen resource
       const fhirSpecimen = fhirBundle.entry?.find(
         (entry) => entry.fullUrl === observation.specimenResourceUuid
       )?.resource;
-      const specimen = parsers(fhirSpecimen) as Specimen;
+      const specimen = parsers(fhirSpecimen) as ParsedSpecimen;
 
       // 2b. Practitioner resource
       const fhirPractitioner = fhirBundle.entry?.find(
         (entry) => entry.fullUrl === observation.practitionerResourceUuid
       )?.resource;
-      const practitioner = parsers(fhirPractitioner) as Practitioner;
+      const practitioner = parsers(fhirPractitioner) as ParsedPractitioner;
 
       // 2c. Organization (Licensed Healthcare Provider) resource
       const fhirOrganizationLhp = fhirBundle.entry?.find(
         (entry) => entry.fullUrl === observation.organizationLhpResourceUuid
       )?.resource;
-      const lhp = parsers(fhirOrganizationLhp) as Organization;
+      const lhp = parsers(fhirOrganizationLhp) as ParsedOrganization;
 
       // 2d. Organization (Accredited Laboratory) resource [Only for PCR]
       const fhirOrganizationAl = fhirBundle.entry?.find(
         (entry) => entry.fullUrl === observation.organizationAlResourceUuid
       )?.resource;
-      const al = parsers(fhirOrganizationAl) as Organization;
+      const al = parsers(fhirOrganizationAl) as ParsedOrganization;
 
       // 2e. Device resource [Only for ART]
       const fhirDevice = fhirBundle.entry?.find(
         (entry) => entry.fullUrl === specimen.deviceResourceUuid
       )?.resource;
-      const device = parsers(fhirDevice) as Device;
+      const device = parsers(fhirDevice) as ParsedDevice;
 
       return {
         observation,
@@ -174,7 +174,7 @@ export const parse = (fhirBundle: R4.IBundle): Bundle => {
       entry.fullUrl ===
       observations?.[0].practitioner.organizationMohResourceUuid
   )?.resource;
-  const moh = parsers(fhirOrganizationMoh) as Organization;
+  const moh = parsers(fhirOrganizationMoh) as ParsedOrganization;
 
   return {
     patient,

--- a/src/models/fhir/required.test.ts
+++ b/src/models/fhir/required.test.ts
@@ -36,8 +36,8 @@ describe("validatePCRHealthCertData", () => {
         thrownError = `${e.title}, ${e.messageBody}`;
       }
     }
-    expect(thrownError).toEqual(
-      `Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: {"observations.0.observation.organizationAlResourceUuid":["Observations 0.observation organization al resource uuid can't be blank"],"observations.0.organization.al.fullName":["Observations 0.organization al full name can't be blank"],"observations.0.organization.al.type":["Observations 0.organization al type can't be blank"],"observations.0.organization.al.url":["Observations 0.organization al url can't be blank"],"observations.0.organization.al.phone":["Observations 0.organization al phone can't be blank"],"observations.0.organization.al.address":["Observations 0.organization al address can't be blank"],"observations.0.organization.al.address.type":["Observations 0.organization al address type can't be blank"],"observations.0.organization.al.address.use":["Observations 0.organization al address use can't be blank"],"observations.0.organization.al.address.text":["Observations 0.organization al address text can't be blank"]}`
+    expect(thrownError).toMatchInlineSnapshot(
+      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'Observation.performer[2].{ id=AL, type=Organization, reference }' is required\\",\\"'0.Organization.name' is required\\",\\"'0.Organization.type[0].coding[0].system' is required\\",\\"'0.Organization.type[0].coding[0].code' is required\\",\\"'0.Organization.type[0].coding[0].display' is required\\",\\"'0.Organization.contact[0].telecom[0].{ system=url, value }' is required\\",\\"'0.Organization.contact[0].telecom[1].{ system=phone, value }' is required\\",\\"'0.Organization.contact[0].address.type' is required\\",\\"'0.Organization.contact[0].address.use' is required\\",\\"'0.Organization.contact[0].address.text' is required\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
     );
   });
 });
@@ -64,8 +64,8 @@ describe("validateARTHealthCertData", () => {
         thrownError = `${e.title}, ${e.messageBody}`;
       }
     }
-    expect(thrownError).toEqual(
-      `Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: {"observations.0.device.type.system":["Observations 0.device type system can't be blank"],"observations.0.device.type.code":["Observations 0.device type code can't be blank"],"observations.0.device.type.display":["Observations 0.device type display can't be blank"]}`
+    expect(thrownError).toMatchInlineSnapshot(
+      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'0.Device.type.coding[0].system' is required\\",\\"'0.Device.type.coding[0].code' is required\\",\\"'0.Device.type.coding[0].display' is required\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
     );
   });
 });

--- a/src/models/fhir/required.ts
+++ b/src/models/fhir/required.ts
@@ -1,195 +1,21 @@
 import validate from "validate.js";
-import { pdtHealthCertV2 } from "@govtechsg/oa-schemata";
-import _ from "lodash";
 import { DocumentInvalidError } from "../../common/error";
 import { ParsedBundle } from "./types";
+import { getConstraints, Type } from "./constraints";
 
-const presenceValidator = { presence: { allowEmpty: false } };
+export const hasRequiredFields = (type: Type, parsedBundle: ParsedBundle) => {
+  const constraints = getConstraints(type, parsedBundle.observations.length);
 
-const getCommonConstraints = (observationCount: number) => {
-  const commonConstraints: any = {
-    /* object validation constraints at here */
+  const errors = validate(parsedBundle, constraints, {
+    fullMessages: false,
+    format: "flat",
+  });
 
-    // patient validation constraints
-    "patient.fullName": presenceValidator,
-    "patient.birthDate": presenceValidator,
-    "patient.nationality.code": presenceValidator,
-    "patient.passportNumber": presenceValidator,
-
-    // organization `moh` validation constraints
-    "organization.moh.fullName": presenceValidator,
-    "organization.moh.type": presenceValidator,
-    "organization.moh.url": presenceValidator,
-    "organization.moh.phone": presenceValidator,
-    "organization.moh.address": presenceValidator,
-    "organization.moh.address.type": presenceValidator,
-    "organization.moh.address.use": presenceValidator,
-    "organization.moh.address.text": presenceValidator,
-  };
-  let counter = 0;
-  while (counter < observationCount) {
-    // observations group validation constraints
-    commonConstraints[
-      `observations.${counter}.observation.specimenResourceUuid`
-    ] = presenceValidator;
-    commonConstraints[
-      `observations.${counter}.observation.practitionerResourceUuid`
-    ] = presenceValidator;
-    commonConstraints[
-      `observations.${counter}.observation.organizationLhpResourceUuid`
-    ] = presenceValidator;
-    commonConstraints[`observations.${counter}.observation.acsn`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.observation.targetDisease`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.observation.testType`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.observation.result`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.observation.effectiveDateTime`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.observation.status`] =
-      presenceValidator;
-
-    // specimen validation constraints
-    commonConstraints[`observations.${counter}.specimen.swabType.code`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.specimen.swabType.display`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.specimen.collectionDateTime`] =
-      presenceValidator;
-
-    // practitioner in observations  group validation constraints
-    commonConstraints[`observations.${counter}.practitioner.fullName`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.practitioner.mcr`] =
-      presenceValidator;
-    commonConstraints[
-      `observations.${counter}.practitioner.organizationMohResourceUuid`
-    ] = presenceValidator;
-
-    // lhp organization in observations  group validation constraints
-    commonConstraints[`observations.${counter}.organization.lhp.fullName`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.organization.lhp.type`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.organization.lhp.url`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.organization.lhp.phone`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.organization.lhp.address`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.organization.lhp.address.type`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.organization.lhp.address.use`] =
-      presenceValidator;
-    commonConstraints[`observations.${counter}.organization.lhp.address.text`] =
-      presenceValidator;
-
-    counter += 1;
-  }
-  return commonConstraints;
-};
-
-const getArtConstraints = (observationCount: number) => {
-  const artConstraints: any = {
-    /* object validation constraints */
-  };
-  let counter = 0;
-  while (counter < observationCount) {
-    // observations group validation constraints
-    artConstraints[`observations.${counter}.specimen.deviceResourceUuid`] =
-      presenceValidator;
-
-    // device validation constraints
-    artConstraints[`observations.${counter}.device.type.system`] =
-      presenceValidator;
-    artConstraints[`observations.${counter}.device.type.code`] =
-      presenceValidator;
-    artConstraints[`observations.${counter}.device.type.display`] =
-      presenceValidator;
-
-    counter += 1;
-  }
-  return artConstraints;
-};
-
-const getPcrConstraints = (observationCount: number) => {
-  const pcrConstraints: any = {
-    /* object validation constraints */
-  };
-  let counter = 0;
-  while (counter < observationCount) {
-    // observations group validation constraints
-    pcrConstraints[
-      `observations.${counter}.observation.organizationAlResourceUuid`
-    ] = presenceValidator;
-
-    // al organization in observations  group validation constraints
-    pcrConstraints[`observations.${counter}.organization.al.fullName`] =
-      presenceValidator;
-    pcrConstraints[`observations.${counter}.organization.al.type`] =
-      presenceValidator;
-    pcrConstraints[`observations.${counter}.organization.al.url`] =
-      presenceValidator;
-    pcrConstraints[`observations.${counter}.organization.al.phone`] =
-      presenceValidator;
-    pcrConstraints[`observations.${counter}.organization.al.address`] =
-      presenceValidator;
-    pcrConstraints[`observations.${counter}.organization.al.address.type`] =
-      presenceValidator;
-    pcrConstraints[`observations.${counter}.organization.al.address.use`] =
-      presenceValidator;
-    pcrConstraints[`observations.${counter}.organization.al.address.text`] =
-      presenceValidator;
-
-    counter += 1;
-  }
-  return pcrConstraints;
-};
-
-type Type = pdtHealthCertV2.PdtTypes | pdtHealthCertV2.PdtTypes[];
-export const hasRequiredFields = (type: Type, bundle: ParsedBundle) => {
-  const { PdtTypes } = pdtHealthCertV2;
-  const supportedMultiType = [PdtTypes.Pcr, PdtTypes.Ser]; // For now, only ["PCR", "SER"] is supported
-  const isValidMultiType = _.isEqual(
-    _.sortBy(supportedMultiType),
-    _.sortBy(type)
-  );
-
-  let constraints = getCommonConstraints(bundle.observations.length);
-
-  if (type === PdtTypes.Art) {
-    // ART HealthCert
-    constraints = {
-      ...constraints,
-      ...getArtConstraints(bundle.observations.length),
-    };
-  } else if (
-    // PCR, SER or PCR + SER HealthCert
-    // Currently PCR and SER have the same validation constraint
-    type === PdtTypes.Pcr ||
-    type === PdtTypes.Ser ||
-    isValidMultiType
-  ) {
-    constraints = {
-      ...constraints,
-      ...getPcrConstraints(bundle.observations.length),
-    };
-  } else {
-    throw new DocumentInvalidError(
-      `Notarise does not support endorsement of this HealthCert Type: ${JSON.stringify(
-        type
-      )}`
-    );
-  }
-
-  const errors = validate(bundle, constraints);
   if (errors) {
     throw new DocumentInvalidError(
       `the following required fields in fhirBundle are missing: ${JSON.stringify(
         errors
-      )}`
+      )}. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38`
     );
   }
 };

--- a/src/models/fhir/required.ts
+++ b/src/models/fhir/required.ts
@@ -2,7 +2,7 @@ import validate from "validate.js";
 import { pdtHealthCertV2 } from "@govtechsg/oa-schemata";
 import _ from "lodash";
 import { DocumentInvalidError } from "../../common/error";
-import { Bundle } from "./types";
+import { ParsedBundle } from "./types";
 
 const presenceValidator = { presence: { allowEmpty: false } };
 
@@ -149,7 +149,7 @@ const getPcrConstraints = (observationCount: number) => {
 };
 
 type Type = pdtHealthCertV2.PdtTypes | pdtHealthCertV2.PdtTypes[];
-export const hasRequiredFields = (type: Type, bundle: Bundle) => {
+export const hasRequiredFields = (type: Type, bundle: ParsedBundle) => {
   const { PdtTypes } = pdtHealthCertV2;
   const supportedMultiType = [PdtTypes.Pcr, PdtTypes.Ser]; // For now, only ["PCR", "SER"] is supported
   const isValidMultiType = _.isEqual(

--- a/src/models/fhir/types.ts
+++ b/src/models/fhir/types.ts
@@ -1,6 +1,6 @@
 import { R4 } from "@ahryman40k/ts-fhir-types";
 
-export interface Patient {
+export interface ParsedPatient {
   fullName: string;
   gender?: R4.PatientGenderKind;
   birthDate: string;
@@ -9,13 +9,13 @@ export interface Patient {
   nricFin?: string;
 }
 
-export interface Specimen {
+export interface ParsedSpecimen {
   deviceResourceUuid?: string;
   swabType: R4.ICoding;
   collectionDateTime: string;
 }
 
-export interface Observation {
+export interface ParsedObservation {
   specimenResourceUuid: string;
   practitionerResourceUuid: string;
   organizationLhpResourceUuid: string;
@@ -28,13 +28,13 @@ export interface Observation {
   status: R4.ObservationStatusKind;
 }
 
-export interface Practitioner {
+export interface ParsedPractitioner {
   fullName: string;
   mcr: string;
   organizationMohResourceUuid: string;
 }
 
-export interface Organization {
+export interface ParsedOrganization {
   fullName: string;
   type: R4.ICoding;
   url: string;
@@ -46,20 +46,20 @@ export interface Organization {
   };
 }
 
-export interface Device {
+export interface ParsedDevice {
   type: R4.ICoding;
 }
 
 export interface GroupedObservation {
-  observation: Observation;
-  specimen: Specimen;
-  device?: Device;
-  practitioner: Practitioner;
-  organization: { lhp: Organization; al?: Organization };
+  observation: ParsedObservation;
+  specimen: ParsedSpecimen;
+  device?: ParsedDevice;
+  practitioner: ParsedPractitioner;
+  organization: { lhp: ParsedOrganization; al?: ParsedOrganization };
 }
 
-export interface Bundle {
-  patient: Patient;
+export interface ParsedBundle {
+  patient: ParsedPatient;
   observations: GroupedObservation[];
-  organization: { moh: Organization };
+  organization: { moh: ParsedOrganization };
 }

--- a/src/models/gpayCovidCard/index.ts
+++ b/src/models/gpayCovidCard/index.ts
@@ -3,13 +3,13 @@ import GPay, {
   BasicDetails,
   TestingRecord,
 } from "@notarise-gov-sg/gpay-covid-cards";
-import { Bundle } from "../../models/fhir/types";
+import { ParsedBundle } from "../../models/fhir/types";
 import { isoToDateOnlyString, isoToLocaleString } from "../../common/datetime";
 import { getDefaultIfUndefined } from "../../config";
 
 const genGPayCovidCardUrl = (
   gpaySigner: { issuer: string; issuerId: string },
-  parsedFhirBundle: Bundle,
+  parsedFhirBundle: ParsedBundle,
   uuid: string,
   storedUrl: string
 ) => {

--- a/src/models/healthCertV2.ts
+++ b/src/models/healthCertV2.ts
@@ -2,7 +2,7 @@ import { pdtHealthCertV2 as healthcert } from "@govtechsg/oa-schemata";
 import moment from "moment-timezone";
 import { TestData } from "src/types";
 import { getNationality } from "../common/nationality";
-import { Bundle } from "./fhir/types";
+import { ParsedBundle } from "./fhir/types";
 
 export const codesDict: Record<string, string> = {
   "260385009": "Negative",
@@ -17,7 +17,7 @@ export const parseDateTime = (dateString: string | undefined): string =>
     : "";
 
 export const getTestDataFromParseFhirBundle = (
-  parseFhirBundle: Bundle
+  parseFhirBundle: ParsedBundle
 ): TestData[] => {
   const testData: TestData[] = [];
   parseFhirBundle.observations.forEach((observationGroup) => {

--- a/src/models/notarizedHealthCertV2/createNotarizedHealthCert/createNotarizedHealthCert.ts
+++ b/src/models/notarizedHealthCertV2/createNotarizedHealthCert/createNotarizedHealthCert.ts
@@ -4,7 +4,7 @@ import {
   SUPPORTED_SIGNING_ALGORITHM,
 } from "@govtechsg/oa-did-sign";
 import { notarise } from "@govtechsg/oa-schemata";
-import { Bundle } from "../../fhir/types";
+import { ParsedBundle } from "../../fhir/types";
 import {
   PDTHealthCertV2Document,
   NotarisedPDTHealthCertV2Document,
@@ -29,7 +29,7 @@ const signWrappedDocument = (
 
 export const createNotarizedHealthCert = async (
   certificate: WrappedDocument<PDTHealthCertV2Document>,
-  parseFhirBundle: Bundle,
+  parseFhirBundle: ParsedBundle,
   reference: string,
   storedUrl: string,
   signedEuHealthCerts?: notarise.SignedEuHealthCert[]

--- a/src/models/notarizedHealthCertV2/createNotarizedHealthCert/createUnwrappedHealthCert.ts
+++ b/src/models/notarizedHealthCertV2/createNotarizedHealthCert/createUnwrappedHealthCert.ts
@@ -1,6 +1,6 @@
 import { getData, v2, WrappedDocument } from "@govtechsg/open-attestation";
 import { notarise } from "@govtechsg/oa-schemata";
-import { Bundle } from "../../fhir/types";
+import { ParsedBundle } from "../../fhir/types";
 import { config } from "../../../config";
 import {
   PDTHealthCertV2Document,
@@ -11,7 +11,7 @@ const { didSigner } = config;
 
 export const createUnwrappedDocument = (
   certificate: WrappedDocument<PDTHealthCertV2Document>,
-  parseFhirBundle: Bundle,
+  parseFhirBundle: ParsedBundle,
   reference: string,
   storedUrl: string,
   signedEuHealthCerts?: notarise.SignedEuHealthCert[]


### PR DESCRIPTION
**What does this PR do?**
- Refactor type names in `src/models/fhir/types.ts` to have a more descriptive name (i.e. `Parsed____`)
- Introduce mappings in `src/models/fhir/constraints.ts` to convert parsed format -> original FHIR Bundle format (to aid in custom error messages)

Validate.js is now used with fully customised messaging:
```javascript
const constraints = {
  "foo.bar": {
    presence: {
      message: `'resource.x.y[0].z' is required`,
      allowEmpty: false,
    },
  },
  "other.constraints": {
    // ...
  },
};

validate(parsedBundle, constraints, { fullMessages: false, format: "flat" })
```

[NEW] Improved error response:
```text
Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: ["'0.Device.type.coding[0].system' is required","'0.Device.type.coding[0].code' is required","'0.Device.type.coding[0].display' is required"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38
```