### PR TITLE
chore: logging-lower-case

### DIFF
--- a/src/middleware/cloudWatch.ts
+++ b/src/middleware/cloudWatch.ts
@@ -81,7 +81,9 @@ export class CloudWatchMiddleware
         ) as Observation;
         let { display } = observation.code.coding[0]; // e.g. Reverse transcription polymerase chain reaction (rRT-PCR) test
         display = display.toLowerCase();
-        testTypes = validTestTypes.filter((test) => display.includes(test));
+        testTypes = validTestTypes
+          .filter((test) => display.includes(test))
+          .map((test) => test.toLowerCase());
       }
       const { specificDomain } = this;
       const aggregateDomain = this.toAggregateDomain(specificDomain);


### PR DESCRIPTION
Right now, the casing of the type is not consistent. Thus, in cloudwatch, "PDT" is differentiated from "pdt"