### PR TITLE
180535117: check against ART whitelist

### DIFF
--- a/src/functionHandlers/notarisePdt/authorizedIssuers/index.ts
+++ b/src/functionHandlers/notarisePdt/authorizedIssuers/index.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import urljoin from "url-join";
+import { pdtHealthCertV2 } from "@govtechsg/oa-schemata";
 import { getLogger } from "../../../common/logger";
 import { config } from "../../../config";
 import { authorizedIssuers } from "./authorizedIssuersMap";
@@ -8,8 +9,10 @@ const { trace, error } = getLogger(
   "src/functionHandlers/notarisePdt/authorizedIssuers/index"
 );
 
+type HealthCertType = `${pdtHealthCertV2.PdtTypes}`;
 export const isAuthorizedIssuerAPI = async (
-  domain: string
+  domain: string,
+  type: HealthCertType
 ): Promise<boolean> => {
   try {
     const headers = {
@@ -20,7 +23,7 @@ export const isAuthorizedIssuerAPI = async (
       `${config.authorizedIssuers.endpoint}`,
       "authorized-issuer",
       domain.toLowerCase(),
-      "pcr"
+      type.toLocaleLowerCase()
     );
     const response = await axios.get(getAuthorizedIssuerUrl, {
       headers,
@@ -39,7 +42,9 @@ export const isAuthorizedIssuerAPI = async (
  * @deprecated This function need to remove after successfully refactor the whitelists
  */
 export const isAuthorizedIssuerLocal = async (
-  domain: string
+  domain: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _type: HealthCertType // type is ignored when checking against local whitelist
 ): Promise<boolean> => authorizedIssuers.has(domain.toLowerCase());
 
 export const getIssuer = authorizedIssuers.get;

--- a/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
+++ b/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
@@ -55,7 +55,7 @@ export const validateDocument = async (
   const issuerDomain: string | undefined = issuer.data[0]?.location;
   if (!issuerDomain)
     throw new DocumentInvalidError("Issuer's domain is not found");
-  const validDomain = await isAuthorizedIssuer(issuerDomain);
+  const validDomain = await isAuthorizedIssuer(issuerDomain, "PCR"); // HealthCerts (in PDT Schema v1.0) are hardcoded to ONLY check against the PCR whitelist
   if (!validDomain) throw new UnrecognisedClinicError(issuerDomain);
 };
 
@@ -93,11 +93,6 @@ export const validateV2Document = async (
   if (!issuer || issuer.data.length !== 1) {
     throw new DocumentInvalidError("Document may only have one issuer");
   }
-  const issuerDomain: string | undefined = issuer.data[0]?.location;
-  if (!issuerDomain)
-    throw new DocumentInvalidError("Issuer's domain is not found");
-  const validDomain = await isAuthorizedIssuer(issuerDomain);
-  if (!validDomain) throw new UnrecognisedClinicError(issuerDomain);
 
   /* 2. Validate against PDT Schema v2.0 */
   const data = getData(wrappedDocument);
@@ -159,4 +154,13 @@ export const validateV2Document = async (
         )}" is supported.`
       );
   }
+
+  /* 3. Check against issuer domain whitelist [api-authorized-issuers] */
+  const issuerDomain: string | undefined = issuer.data[0]?.location;
+  if (!issuerDomain)
+    throw new DocumentInvalidError("Issuer's domain is not found");
+  const testType = _.isString(data.type) ? data.type : "PCR"; // When HealthCert is a multi type, check against PCR whitelist
+
+  const validDomain = await isAuthorizedIssuer(issuerDomain, testType);
+  if (!validDomain) throw new UnrecognisedClinicError(issuerDomain);
 };


### PR DESCRIPTION
## Context
Codebase is currently hardcoded to ONLY check against the PCR whitelist in `api-authorized-issuers`. This caused incorrect `UnrecognisedClinicError` to be thrown when a valid ART provider is attempting to endorse a valid HealthCert.

## What does this PR do?
**For HealthCerts in PDT Schema v1.0**:
Continue to ONLY check against the PCR whitelist as there is no straightforward way to distinguish between PCR and ART HealthCerts. PDT Schema v1.0 is also about to be deprecated.

**For HealthCerts in PDT Schema v2.0**:
1. Check if HealthCert is single type (e.g. `"PCR"`) or multi type (e.g. `["PCR", "SER"]`).
2. If **single type**: Query respective whitelist (i.e. `whitelist.com/authorized-issuer/{domain}/{type}`)
3. If **multi type**: Hardcoded to ONLY check against PCR whitelist (since PCR and SER has the same validation rules)