### PR TITLE
fix: improve logs for UnrecognisedClinicError

### DIFF
--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -73,15 +73,15 @@ export class DetailedCodedError extends AbstractError {
 }
 
 export class UnrecognisedClinicError extends DetailedCodedError {
-  constructor(issuerDomain: string) {
+  constructor(issuerDomain: string, type: string) {
     errorLogger(
-      `UnrecognisedClinicError triggered by issuer domain: ${issuerDomain}`
+      `UnrecognisedClinicError triggered by issuer domain: ${issuerDomain} (${type})`
     );
     super(
       "Unrecognised clinic error",
       ErrorCodes.UNRECOGNISED_CLINIC,
       ErrorCodes[ErrorCodes.UNRECOGNISED_CLINIC],
-      `Submitted HealthCert not from recognised clinic - ${issuerDomain}`,
+      `Submitted HealthCert not a recognised/whitelisted clinic - ${issuerDomain} (${type})`,
       "The HealthCert was not issued by a clinic recognised by the Ministry of Health Singapore"
     );
   }

--- a/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
+++ b/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
@@ -56,7 +56,7 @@ export const validateDocument = async (
   if (!issuerDomain)
     throw new DocumentInvalidError("Issuer's domain is not found");
   const validDomain = await isAuthorizedIssuer(issuerDomain, "PCR"); // HealthCerts (in PDT Schema v1.0) are hardcoded to ONLY check against the PCR whitelist
-  if (!validDomain) throw new UnrecognisedClinicError(issuerDomain);
+  if (!validDomain) throw new UnrecognisedClinicError(issuerDomain, "PCR");
 };
 
 export const validateV2Document = async (
@@ -162,5 +162,5 @@ export const validateV2Document = async (
   const testType = _.isString(data.type) ? data.type : "PCR"; // When HealthCert is a multi type, check against PCR whitelist
 
   const validDomain = await isAuthorizedIssuer(issuerDomain, testType);
-  if (!validDomain) throw new UnrecognisedClinicError(issuerDomain);
+  if (!validDomain) throw new UnrecognisedClinicError(issuerDomain, testType);
 };


### PR DESCRIPTION
Log HealthCert type (e.g. `"PCR"`, `"ART"`, etc.) along with issuer domain when an `UnrecognisedClinicError` occurs