### PR TITLE
180725514 : Add logic to remove child record from SPM Notification if below 15 years old

### DIFF
--- a/src/functionHandlers/notarisePdt/v1/notarisePdt.ts
+++ b/src/functionHandlers/notarisePdt/v1/notarisePdt.ts
@@ -7,7 +7,7 @@ import {
 import { getLogger } from "../../../common/logger";
 import { createNotarizedHealthCert } from "../../../models/notarizedHealthCert";
 import {
-  buildStoredUrl,
+  buildUniversalUrl,
   getQueueNumber,
   uploadDocument,
 } from "../../../services/transientStorage";
@@ -32,7 +32,7 @@ export const notarisePdt = async (
   const { id, key } = await getQueueNumber(reference);
   traceWithRef(`placeholder document id: ${id}`);
 
-  const storedUrl = buildStoredUrl(id, key);
+  const universalUrl = buildUniversalUrl(id, key);
   const data = getData(certificate);
   const testData = getTestDataFromHealthCert(data);
   const { nric, fin } = getParticularsFromHealthCert(data);
@@ -54,7 +54,7 @@ export const notarisePdt = async (
         testDataTypes.includes(config.swabTestTypes.PCR)
       ) {
         traceWithRef("signedEuHealthCerts: Generating EU test cert...");
-        const euTestCerts = createEuTestCert(testData, reference, storedUrl);
+        const euTestCerts = createEuTestCert(testData, reference, universalUrl);
         traceWithRef(euTestCerts);
         signedEuHealthCerts = await createEuSignedTestQr(euTestCerts);
         if (!signedEuHealthCerts.length) {
@@ -79,7 +79,7 @@ export const notarisePdt = async (
   const notarisedDocument = await createNotarizedHealthCert(
     certificate,
     reference,
-    storedUrl,
+    universalUrl,
     signedEuHealthCerts
   );
   const { ttl } = await uploadDocument(notarisedDocument, id, reference);
@@ -87,6 +87,6 @@ export const notarisePdt = async (
   return {
     notarisedDocument,
     ttl,
-    url: storedUrl,
+    url: universalUrl,
   };
 };

--- a/src/functionHandlers/notarisePdt/v2/handler.ts
+++ b/src/functionHandlers/notarisePdt/v2/handler.ts
@@ -84,12 +84,7 @@ export const main: Handler = async (
   /* Send to SPM notification/wallet (Only if enabled) */
   if (config.notification.enabled) {
     try {
-      await sendNotification(
-        result,
-        parsedFhirBundle,
-        testData,
-        data.validFrom
-      );
+      await sendNotification(result, parsedFhirBundle, testData, data);
     } catch (e) {
       if (e instanceof Error) {
         errorWithRef(`SPM notification/wallet error: ${e.message}`);

--- a/src/functionHandlers/notarisePdt/v2/notarisePdt.ts
+++ b/src/functionHandlers/notarisePdt/v2/notarisePdt.ts
@@ -4,7 +4,7 @@ import { ParsedBundle } from "../../../models/fhir/types";
 import { getLogger } from "../../../common/logger";
 import { createNotarizedHealthCert } from "../../../models/notarizedHealthCertV2";
 import {
-  buildStoredUrl,
+  buildUniversalUrl,
   getQueueNumber,
   uploadDocument,
 } from "../../../services/transientStorage";
@@ -29,7 +29,7 @@ export const notarisePdt = async (
   const { id, key } = await getQueueNumber(reference);
   traceWithRef(`placeholder document id: ${id}`);
 
-  const storedUrl = buildStoredUrl(id, key);
+  const universalUrl = buildUniversalUrl(id, key);
 
   const whiteListNrics = getDefaultIfUndefined(process.env.WHITELIST_NRICS, "")
     .split(",")
@@ -52,7 +52,7 @@ export const notarisePdt = async (
         const euTestCerts = await createEuTestCert(
           testData,
           reference,
-          storedUrl
+          universalUrl
         );
         traceWithRef(euTestCerts);
         signedEuHealthCerts = await createEuSignedTestQr(euTestCerts);
@@ -79,7 +79,7 @@ export const notarisePdt = async (
     certificate,
     parsedFhirBundle,
     reference,
-    storedUrl,
+    universalUrl,
     signedEuHealthCerts
   );
   const { ttl } = await uploadDocument(notarisedDocument, id, reference);
@@ -87,6 +87,6 @@ export const notarisePdt = async (
   return {
     notarisedDocument,
     ttl,
-    url: storedUrl,
+    url: universalUrl,
   };
 };

--- a/src/functionHandlers/notarisePdt/v2/notarisePdt.ts
+++ b/src/functionHandlers/notarisePdt/v2/notarisePdt.ts
@@ -4,7 +4,6 @@ import { ParsedBundle } from "../../../models/fhir/types";
 import { getLogger } from "../../../common/logger";
 import { createNotarizedHealthCert } from "../../../models/notarizedHealthCertV2";
 import {
-  buildStoredDirectUrl,
   buildStoredUrl,
   getQueueNumber,
   uploadDocument,
@@ -23,14 +22,13 @@ export const notarisePdt = async (
   certificate: WrappedDocument<PDTHealthCertV2>,
   parsedFhirBundle: ParsedBundle,
   testData: TestData[]
-): Promise<{ result: NotarisationResult; directUrl: string }> => {
+): Promise<NotarisationResult> => {
   const errorWithRef = trace.extend(`reference:${reference}`);
   const traceWithRef = trace.extend(`reference:${reference}`);
 
   const { id, key } = await getQueueNumber(reference);
   traceWithRef(`placeholder document id: ${id}`);
 
-  const directUrl = buildStoredDirectUrl(id, key);
   const storedUrl = buildStoredUrl(id, key);
 
   const whiteListNrics = getDefaultIfUndefined(process.env.WHITELIST_NRICS, "")
@@ -87,11 +85,8 @@ export const notarisePdt = async (
   const { ttl } = await uploadDocument(notarisedDocument, id, reference);
   traceWithRef("Document successfully notarised");
   return {
-    result: {
-      notarisedDocument,
-      ttl,
-      url: storedUrl,
-    },
-    directUrl,
+    notarisedDocument,
+    ttl,
+    url: storedUrl,
   };
 };

--- a/src/services/spmNotification/index.test.ts
+++ b/src/services/spmNotification/index.test.ts
@@ -1,0 +1,383 @@
+import {
+  notifyHealthCert,
+  notifyPdt,
+} from "@notarise-gov-sg/sns-notify-recipients";
+import { ParsedBundle, GroupedObservation } from "../../models/fhir/types";
+import { NotarisationResult, TestData } from "../../types";
+import { config } from "../../config";
+import { sendNotification } from "./index";
+
+jest.mock("@notarise-gov-sg/sns-notify-recipients");
+
+describe("single type oa-doc notification", () => {
+  let parsedFhirBundleMock: ParsedBundle;
+  let testDataMock: TestData[];
+  let groupedObservationMock: GroupedObservation[];
+  let resultMock: NotarisationResult;
+  let spy: jest.SpyInstance;
+  beforeAll(() => {
+    spy = jest.spyOn(console, "error").mockImplementation(() => {
+      // do not display errors
+    });
+    config.healthCertNotification.enabled = true;
+  });
+  beforeEach(() => {
+    resultMock = {
+      notarisedDocument: "notarisedDocument" as any,
+      ttl: 12345678,
+      url: "verify.sg/url",
+      gpayCovidCardUrl: "gpay.com/url",
+    };
+    groupedObservationMock = [
+      {
+        observation: {
+          testType: {
+            code: "258500001",
+            display: "Nasopharyngeal swab",
+          },
+          specimenResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12345",
+          practitionerResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12346",
+          organizationAlResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12347",
+          organizationLhpResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12348",
+          acsn: "123456789",
+          targetDisease: {
+            code: "840539006",
+            display: "COVID-19",
+          },
+          result: {
+            code: "260385009",
+            display: "Negative",
+          },
+          effectiveDateTime: "2020-09-28T06:15:00Z",
+          status: "final" as any,
+        },
+        specimen: {} as any,
+        practitioner: {} as any,
+        organization: {} as any,
+      },
+    ];
+    parsedFhirBundleMock = {
+      patient: {
+        fullName: "Tan Chen Chen",
+        nricFin: "S9098989Z",
+        birthDate: "1990-01-15",
+        passportNumber: "E7831177G",
+        nationality: {
+          code: "SG",
+        },
+      },
+      observations: groupedObservationMock,
+      organization: {} as any,
+    };
+    testDataMock = [
+      {
+        provider: "MacRitchie Medical Clinic",
+        gender: "M",
+        lab: "lab",
+        nationality: "SG",
+        nric: "123",
+        observationDate: "6/28/21 2:15:00 PM GMT+08:00",
+        passportNumber: "ES12345",
+        patientName: "TESTING",
+        performerMcr: "123",
+        performerName: "123",
+        birthDate: "01/01/2021",
+        swabCollectionDate: "6/27/21 2:15:00 PM GMT+08:00",
+        swabType: "Nasopharyngeal swab",
+        swabTypeCode: "258500001",
+        testCode: "94531-1",
+        testType:
+          "Reverse transcription polymerase chain reaction (rRT-PCR) test",
+        testResult: "Negative",
+        testResultCode: "260385009",
+      },
+    ];
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    spy.mockRestore();
+  });
+
+  it("skip notifyHealthCert/notifyPdt for child valid test cert", async () => {
+    // set patient dob to 5 years old (less than 15 years)
+    parsedFhirBundleMock.patient.birthDate = new Date(
+      new Date().getFullYear() - 5,
+      1,
+      1
+    ).toISOString();
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+    expect(notifyHealthCert).toBeCalledTimes(0);
+    expect(notifyPdt).toBeCalledTimes(0);
+  });
+
+  it("skip notifyHealthCert/notifyPdt for valid PCR test cert without nric/fin", async () => {
+    // remove patient nric/fin
+    delete parsedFhirBundleMock.patient.nricFin;
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+    expect(notifyHealthCert).toBeCalledTimes(0);
+    expect(notifyPdt).toBeCalledTimes(0);
+  });
+
+  it("trigger notifyPdt for single valid SER test cert", async () => {
+    // set test type code to SER
+    parsedFhirBundleMock.observations[0].observation.testType = {
+      code: "94661-6",
+      display: "SARS-CoV-2 (COVID-19) Ab [Interpretation] in Serum or Plasma",
+    };
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+    expect(notifyPdt).toBeCalledTimes(1);
+    expect(notifyPdt).toHaveBeenCalledWith({
+      nric: parsedFhirBundleMock.patient.nricFin,
+      passportNumber: parsedFhirBundleMock.patient.passportNumber,
+      testData: testDataMock,
+      url: resultMock.url,
+      validFrom: "2021-08-24T04:22:36.062Z",
+    });
+  });
+
+  it("trigger notifyHealthCert for valid ART test cert", async () => {
+    // set test type code to ART
+    parsedFhirBundleMock.observations[0].observation.testType = {
+      code: "697989009",
+      display: "Anterior nares swab",
+    };
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+
+    expect(notifyHealthCert).toBeCalledTimes(1);
+    expect(notifyHealthCert).toHaveBeenCalledWith({
+      expiry: resultMock.ttl,
+      type: "ART",
+      uin: parsedFhirBundleMock.patient.nricFin,
+      url: resultMock.url,
+      version: "2.0",
+    });
+  });
+
+  it("trigger notifyHealthCert for valid PCR test cert", async () => {
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+
+    expect(notifyHealthCert).toBeCalledTimes(1);
+    expect(notifyHealthCert).toHaveBeenCalledWith({
+      expiry: resultMock.ttl,
+      type: "PCR",
+      uin: parsedFhirBundleMock.patient.nricFin,
+      url: resultMock.url,
+      version: "2.0",
+    });
+  });
+});
+
+describe("multi type oa-doc notification", () => {
+  let parsedFhirBundleMock: ParsedBundle;
+  let testDataMock: TestData[];
+  let groupedObservationMock: GroupedObservation[];
+  let resultMock: NotarisationResult;
+  let spy: jest.SpyInstance;
+  beforeAll(() => {
+    spy = jest.spyOn(console, "error").mockImplementation(() => {
+      // do not display errors
+    });
+    config.healthCertNotification.enabled = true;
+  });
+  beforeEach(() => {
+    resultMock = {
+      notarisedDocument: "notarisedDocument" as any,
+      ttl: 12345678,
+      url: "verify.sg/url",
+      gpayCovidCardUrl: "gpay.com/url",
+    };
+    groupedObservationMock = [
+      {
+        observation: {
+          testType: {
+            code: "258500001",
+            display: "Nasopharyngeal swab",
+          },
+          specimenResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12345",
+          practitionerResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12346",
+          organizationAlResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12347",
+          organizationLhpResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-12348",
+          acsn: "123456789",
+          targetDisease: {
+            code: "840539006",
+            display: "COVID-19",
+          },
+          result: {
+            code: "260385009",
+            display: "Negative",
+          },
+          effectiveDateTime: "2020-09-28T06:15:00Z",
+          status: "final" as any,
+        },
+        specimen: {} as any,
+        practitioner: {} as any,
+        organization: {} as any,
+      },
+      {
+        observation: {
+          testType: {
+            code: "94661-6",
+            display:
+              "SARS-CoV-2 (COVID-19) Ab [Interpretation] in Serum or Plasma",
+          },
+          specimenResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-123425",
+          practitionerResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-123426",
+          organizationAlResourceUuid: "urn:uuid:0275bfaf-48fb-44e0-80cd-123427",
+          organizationLhpResourceUuid:
+            "urn:uuid:0275bfaf-48fb-44e0-80cd-123428",
+          acsn: "123456789",
+          targetDisease: {
+            code: "840539006",
+            display: "COVID-19",
+          },
+          result: {
+            code: "260385009",
+            display: "Negative",
+          },
+          effectiveDateTime: "2020-09-28T06:15:00Z",
+          status: "final" as any,
+        },
+        specimen: {} as any,
+        practitioner: {} as any,
+        organization: {} as any,
+      },
+    ];
+    parsedFhirBundleMock = {
+      patient: {
+        fullName: "Tan Chen Chen",
+        nricFin: "S9098989Z",
+        birthDate: "1990-01-15",
+        passportNumber: "E7831177G",
+        nationality: {
+          code: "SG",
+        },
+      },
+      observations: groupedObservationMock,
+      organization: {} as any,
+    };
+    testDataMock = [
+      {
+        provider: "MacRitchie Medical Clinic",
+        gender: "M",
+        lab: "lab",
+        nationality: "SG",
+        nric: "123",
+        observationDate: "6/28/21 2:15:00 PM GMT+08:00",
+        passportNumber: "ES12345",
+        patientName: "TESTING",
+        performerMcr: "123",
+        performerName: "123",
+        birthDate: "01/01/2021",
+        swabCollectionDate: "6/27/21 2:15:00 PM GMT+08:00",
+        swabType: "Nasopharyngeal swab",
+        swabTypeCode: "258500001",
+        testCode: "94531-1",
+        testType:
+          "Reverse transcription polymerase chain reaction (rRT-PCR) test",
+        testResult: "Negative",
+        testResultCode: "260385009",
+      },
+      {
+        provider: "MacRitchie Medical Clinic",
+        gender: "M",
+        lab: "lab",
+        nationality: "SG",
+        nric: "123",
+        observationDate: "6/28/21 2:15:00 PM GMT+08:00",
+        passportNumber: "ES12345",
+        patientName: "TESTING",
+        performerMcr: "123",
+        performerName: "123",
+        birthDate: "01/01/2021",
+        swabCollectionDate: "6/27/21 2:15:00 PM GMT+08:00",
+        swabType: "Nasopharyngeal swab",
+        swabTypeCode: "258500001",
+        testCode: "94661-6",
+        testType:
+          "SARS-CoV-2 (COVID-19) Ab [Interpretation] in Serum or Plasma",
+        testResult: "Negative",
+        testResultCode: "260385009",
+      },
+    ];
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    spy.mockRestore();
+  });
+
+  it("skip notifyHealthCert/notifyPdt for child valid [PCR, SER] test cert", async () => {
+    // set patient dob to 5 years old (less than 15 years)
+    parsedFhirBundleMock.patient.birthDate = new Date(
+      new Date().getFullYear() - 5,
+      1,
+      1
+    ).toISOString();
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+    expect(notifyHealthCert).toBeCalledTimes(0);
+    expect(notifyPdt).toBeCalledTimes(0);
+  });
+
+  it("skip notifyHealthCert/notifyPdt for [PCR, SER] test cert without nric/fin", async () => {
+    // remove patient nric/fin
+    delete parsedFhirBundleMock.patient.nricFin;
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+    expect(notifyHealthCert).toBeCalledTimes(0);
+    expect(notifyPdt).toBeCalledTimes(0);
+  });
+
+  it("trigger notifyPdt for valid [PCR, SER] test cert", async () => {
+    await sendNotification(
+      resultMock,
+      parsedFhirBundleMock,
+      testDataMock,
+      "2021-08-24T04:22:36.062Z"
+    );
+    expect(notifyPdt).toBeCalledTimes(1);
+    expect(notifyPdt).toHaveBeenCalledWith({
+      nric: parsedFhirBundleMock.patient.nricFin,
+      passportNumber: parsedFhirBundleMock.patient.passportNumber,
+      testData: testDataMock,
+      url: resultMock.url,
+      validFrom: "2021-08-24T04:22:36.062Z",
+    });
+  });
+});

--- a/src/services/spmNotification/index.test.ts
+++ b/src/services/spmNotification/index.test.ts
@@ -3,17 +3,18 @@ import {
   notifyPdt,
 } from "@notarise-gov-sg/sns-notify-recipients";
 import { ParsedBundle, GroupedObservation } from "../../models/fhir/types";
-import { NotarisationResult, TestData } from "../../types";
+import { NotarisationResult, TestData, PDTHealthCertV2 } from "../../types";
 import { config } from "../../config";
 import { sendNotification } from "./index";
 
 jest.mock("@notarise-gov-sg/sns-notify-recipients");
 
 describe("single type oa-doc notification", () => {
+  let certificateData: PDTHealthCertV2;
+  let resultMock: NotarisationResult;
+  let groupedObservationMock: GroupedObservation[];
   let parsedFhirBundleMock: ParsedBundle;
   let testDataMock: TestData[];
-  let groupedObservationMock: GroupedObservation[];
-  let resultMock: NotarisationResult;
   let spy: jest.SpyInstance;
   beforeAll(() => {
     spy = jest.spyOn(console, "error").mockImplementation(() => {
@@ -22,6 +23,10 @@ describe("single type oa-doc notification", () => {
     config.healthCertNotification.enabled = true;
   });
   beforeEach(() => {
+    certificateData = {
+      validFrom: "2021-08-24T04:22:36.062Z",
+      type: "PCR" as any,
+    } as any;
     resultMock = {
       notarisedDocument: "notarisedDocument" as any,
       ttl: 12345678,
@@ -111,7 +116,7 @@ describe("single type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
     expect(notifyHealthCert).toBeCalledTimes(0);
     expect(notifyPdt).toBeCalledTimes(0);
@@ -124,7 +129,7 @@ describe("single type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
     expect(notifyHealthCert).toBeCalledTimes(0);
     expect(notifyPdt).toBeCalledTimes(0);
@@ -132,6 +137,7 @@ describe("single type oa-doc notification", () => {
 
   it("trigger notifyPdt for single valid SER test cert", async () => {
     // set test type code to SER
+    certificateData.type = "SER" as any;
     parsedFhirBundleMock.observations[0].observation.testType = {
       code: "94661-6",
       display: "SARS-CoV-2 (COVID-19) Ab [Interpretation] in Serum or Plasma",
@@ -140,7 +146,7 @@ describe("single type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
     expect(notifyPdt).toBeCalledTimes(1);
     expect(notifyPdt).toHaveBeenCalledWith({
@@ -148,12 +154,13 @@ describe("single type oa-doc notification", () => {
       passportNumber: parsedFhirBundleMock.patient.passportNumber,
       testData: testDataMock,
       url: resultMock.url,
-      validFrom: "2021-08-24T04:22:36.062Z",
+      validFrom: certificateData.validFrom,
     });
   });
 
   it("trigger notifyHealthCert for valid ART test cert", async () => {
     // set test type code to ART
+    certificateData.type = "ART" as any;
     parsedFhirBundleMock.observations[0].observation.testType = {
       code: "697989009",
       display: "Anterior nares swab",
@@ -162,7 +169,7 @@ describe("single type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
 
     expect(notifyHealthCert).toBeCalledTimes(1);
@@ -180,7 +187,7 @@ describe("single type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
 
     expect(notifyHealthCert).toBeCalledTimes(1);
@@ -195,10 +202,11 @@ describe("single type oa-doc notification", () => {
 });
 
 describe("multi type oa-doc notification", () => {
+  let certificateData: PDTHealthCertV2;
+  let resultMock: NotarisationResult;
+  let groupedObservationMock: GroupedObservation[];
   let parsedFhirBundleMock: ParsedBundle;
   let testDataMock: TestData[];
-  let groupedObservationMock: GroupedObservation[];
-  let resultMock: NotarisationResult;
   let spy: jest.SpyInstance;
   beforeAll(() => {
     spy = jest.spyOn(console, "error").mockImplementation(() => {
@@ -207,6 +215,10 @@ describe("multi type oa-doc notification", () => {
     config.healthCertNotification.enabled = true;
   });
   beforeEach(() => {
+    certificateData = {
+      validFrom: "2021-08-24T04:22:36.062Z",
+      type: ["PCR", "SER"] as any,
+    } as any;
     resultMock = {
       notarisedDocument: "notarisedDocument" as any,
       ttl: 12345678,
@@ -345,7 +357,7 @@ describe("multi type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
     expect(notifyHealthCert).toBeCalledTimes(0);
     expect(notifyPdt).toBeCalledTimes(0);
@@ -358,7 +370,7 @@ describe("multi type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
     expect(notifyHealthCert).toBeCalledTimes(0);
     expect(notifyPdt).toBeCalledTimes(0);
@@ -369,7 +381,7 @@ describe("multi type oa-doc notification", () => {
       resultMock,
       parsedFhirBundleMock,
       testDataMock,
-      "2021-08-24T04:22:36.062Z"
+      certificateData
     );
     expect(notifyPdt).toBeCalledTimes(1);
     expect(notifyPdt).toHaveBeenCalledWith({
@@ -377,7 +389,7 @@ describe("multi type oa-doc notification", () => {
       passportNumber: parsedFhirBundleMock.patient.passportNumber,
       testData: testDataMock,
       url: resultMock.url,
-      validFrom: "2021-08-24T04:22:36.062Z",
+      validFrom: certificateData.validFrom,
     });
   });
 });

--- a/src/services/spmNotification/index.ts
+++ b/src/services/spmNotification/index.ts
@@ -1,0 +1,67 @@
+import {
+  notifyHealthCert,
+  notifyPdt,
+} from "@notarise-gov-sg/sns-notify-recipients";
+import _ from "lodash";
+import moment from "moment-timezone";
+import { ParsedBundle } from "../../models/fhir/types";
+import { config } from "../../config";
+import { NotarisationResult, TestData } from "../../types";
+
+const isChildPatient = (parsedFhirBundle: ParsedBundle): boolean => {
+  const patientDOB = parsedFhirBundle.patient.birthDate;
+  return moment().diff(patientDOB, "years") < 15;
+};
+
+const isEligibleForSpmWallet = (parsedFhirBundle: ParsedBundle): boolean => {
+  const testTypeCode =
+    parsedFhirBundle.observations[0].observation.testType.code || "";
+  /* 
+  [NEW] SPM wallet notification support only for; 
+    - single type OA-Doc PCR or ART (currently, doesn't support either single-type 'SER' or multi-type ['PCR', 'SER'].)
+  */
+  return (
+    parsedFhirBundle.observations.length === 1 &&
+    Object.values(config.swabTestTypes).includes(testTypeCode)
+  );
+};
+
+export const sendNotification = async (
+  result: NotarisationResult,
+  parsedFhirBundle: ParsedBundle,
+  testData: TestData[],
+  validFrom: string
+) => {
+  /* Send SPM notification using api-notify/wallet when patient is adult (15 years & above) and present NRIC-FIN in OA-Doc. */
+  if (parsedFhirBundle.patient?.nricFin && !isChildPatient(parsedFhirBundle)) {
+    /* [NEW] Send HealthCert to SPM wallet for PCR | ART (Only if enabled) */
+    if (
+      config.healthCertNotification.enabled &&
+      isEligibleForSpmWallet(parsedFhirBundle)
+    ) {
+      const testType =
+        _.findKey(
+          config.swabTestTypes,
+          (swabTestType) =>
+            swabTestType ===
+            parsedFhirBundle.observations[0].observation.testType.code
+        ) || "";
+      await notifyHealthCert({
+        uin: parsedFhirBundle.patient?.nricFin,
+        version: "2.0",
+        type: testType,
+        url: result.url,
+        expiry: result.ttl,
+      });
+    } else {
+      /* Send SPM notification to recipient (Only if enabled) */
+      await notifyPdt({
+        url: result.url,
+        nric: parsedFhirBundle.patient?.nricFin,
+        passportNumber: parsedFhirBundle.patient?.passportNumber,
+        testData,
+        validFrom,
+      });
+    }
+  }
+};

--- a/src/services/transientStorage/index.ts
+++ b/src/services/transientStorage/index.ts
@@ -8,7 +8,7 @@ import {
 import { config } from "../../config";
 import { getLogger } from "../../common/logger";
 
-const { trace } = getLogger("api-notarise-healthcerts");
+const { trace } = getLogger("src/services/transientStorage");
 
 export const SuccessfulGetQueueNumberResponseDef = Record({
   id: String,
@@ -53,23 +53,6 @@ const universalUrl = (url: string, key: string) => {
 export const buildStoredUrl = (id: string, key: string) => {
   const url = `${endpoint}/${id}`;
   return universalUrl(url, key);
-};
-
-const universalDirectUrl = (url: string, key: string) => {
-  const query = stringifyAndEncode({
-    type: "DOCUMENT",
-    payload: {
-      uri: url,
-      permittedActions: ["VIEW", "STORE"],
-    },
-  });
-  const anchor = key ? `#${stringifyAndEncode({ key })}` : ``;
-  return `https://www.verify.gov.sg/verify?q=${query}${anchor}`;
-};
-
-export const buildStoredDirectUrl = (id: string, key: string) => {
-  const url = `${endpoint}/${id}`;
-  return universalDirectUrl(url, key);
 };
 
 export const getQueueNumber = async (reference: string) => {

--- a/src/services/transientStorage/index.ts
+++ b/src/services/transientStorage/index.ts
@@ -50,7 +50,7 @@ const universalUrl = (url: string, key: string) => {
   return `${fullDomainToVerifyPath}?q=${query}${anchor}`;
 };
 
-export const buildStoredUrl = (id: string, key: string) => {
+export const buildUniversalUrl = (id: string, key: string) => {
   const url = `${endpoint}/${id}`;
   return universalUrl(url, key);
 };


### PR DESCRIPTION
**What does this PR do?**
- remove multiple `directUrl` converting and change log path in transientStorage service
- refactor `spmNotification` service for v2 endpoint
- add logic for skip SPM Notification if the patient age is below 15 years
- add unit tests for `spmNotification` service