### PR TITLE
feat: validate test result codes

### DIFF
--- a/src/functionHandlers/notarisePdt/v2/handler.ts
+++ b/src/functionHandlers/notarisePdt/v2/handler.ts
@@ -40,6 +40,7 @@ export const main: Handler = async (
 
     // validate parsed FhirBundle data with specific healthcert type constraints
     fhirHelper.hasRequiredFields(data.type, parsedFhirBundle);
+    fhirHelper.hasRecognisedFields(data.type, parsedFhirBundle);
 
     // convert parsed Bundle to testdata[]
     testData = getTestDataFromParseFhirBundle(parsedFhirBundle);

--- a/src/functionHandlers/notarisePdt/validateInputs/validateDocument.test.ts
+++ b/src/functionHandlers/notarisePdt/validateInputs/validateDocument.test.ts
@@ -365,9 +365,7 @@ describe("document logo validation", () => {
     });
   });
 
-  // FIXME: Temporarily disable logo size checking
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should throw on large base64 image string (>20KB)", async () => {
+  it("should throw on large base64 image string (>20KB)", async () => {
     const sampleDocumentV2InvalidLogo = { ...examplePcrHealthCertV2Wrapped };
     sampleDocumentV2InvalidLogo.data.logo = `a60dd179-4029-44c5-8b77-296b10412836:string:${mockImage["33KB"]}`;
 
@@ -381,7 +379,7 @@ describe("document logo validation", () => {
     }
     expect(thrownError).toStrictEqual({
       title: `Submitted HealthCert is invalid`,
-      body: `Document logo in base64 image string is too large (33.95KB). Only <=20KB is supported.`,
+      body: `Document "logo" in base64 image string is too large (33.95KB). Only <=20KB is supported.`,
     });
   });
 

--- a/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
+++ b/src/functionHandlers/notarisePdt/validateInputs/validateDocument.ts
@@ -177,7 +177,7 @@ export const validateV2Document = async (
       // Either base64 string or https URL in .png | .jpg | .jpeg format
       /(^data:image\/(png|jpg|jpeg);base64,.*$)|(^https:\/\/.*[.](png|jpg|jpeg)$)/;
     const VALID_MIME_PATTERN = /^image\/(png|jpeg)$/;
-    // const MAX_LOGO_SIZE_IN_KILOBYTES = 20 * 1024; // 20KB
+    const MAX_LOGO_SIZE_IN_KILOBYTES = 20 * 1024; // 20KB
 
     if (!VALID_LOGO_PATTERN.test(data.logo)) {
       throw new DocumentInvalidError(
@@ -209,19 +209,18 @@ export const validateV2Document = async (
         );
       }
 
-      // FIXME: Temporarily disable logo size checking
-      // if (data.logo.startsWith("data:")) {
-      //   const byteLength = Buffer.byteLength(data.logo, "utf-8");
-      //   if (byteLength >= MAX_LOGO_SIZE_IN_KILOBYTES) {
-      //     throw new DocumentInvalidError(
-      //       `Document logo in base64 image string is too large (${(
-      //         byteLength / 1024
-      //       ).toFixed(2)}KB). Only <=${
-      //         MAX_LOGO_SIZE_IN_KILOBYTES / 1024
-      //       }KB is supported.`
-      //     );
-      //   }
-      // }
+      if (data.logo.startsWith("data:")) {
+        const byteLength = Buffer.byteLength(data.logo, "utf-8");
+        if (byteLength >= MAX_LOGO_SIZE_IN_KILOBYTES) {
+          throw new DocumentInvalidError(
+            `Document "logo" in base64 image string is too large (${(
+              byteLength / 1024
+            ).toFixed(2)}KB). Only <=${
+              MAX_LOGO_SIZE_IN_KILOBYTES / 1024
+            }KB is supported.`
+          );
+        }
+      }
     }
   }
 };

--- a/src/models/fhir/constraints.ts
+++ b/src/models/fhir/constraints.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { pdtHealthCertV2 } from "@govtechsg/oa-schemata";
 import { DocumentInvalidError } from "../../common/error";
+import euDccTestResultMapping from "../../static/EU-DCC-test-result.mapping.json";
 
 /**
  * Common constraints required by all types of HealthCerts:
@@ -248,4 +249,30 @@ export const getRequiredConstraints = (
       )}`
     );
   }
+};
+
+export const getRecognisedConstraints = (
+  _type: Type,
+  observationCount: number
+) => {
+  const constraints: Record<string, any> = {};
+
+  /* Inclusion validation: Limit to 2 sets of Test Result Codes */
+  const recognisedTestResultCodes = [
+    ...Object.keys(euDccTestResultMapping),
+    ...Object.values(euDccTestResultMapping),
+  ];
+  for (let i = 0; i < observationCount; i += 1) {
+    const k = `observations._.observation.result.code`;
+    const parsedKey = k.replace("_", i.toString());
+    const fhirKey = commonGroupedFhirKeys[k].replace("_", i.toString());
+    constraints[parsedKey] = {
+      inclusion: {
+        within: recognisedTestResultCodes,
+        message: `'${fhirKey}' is an unrecognised code - please use of the following codes: ${recognisedTestResultCodes}`,
+      },
+    };
+  }
+
+  return constraints;
 };

--- a/src/models/fhir/constraints.ts
+++ b/src/models/fhir/constraints.ts
@@ -269,7 +269,7 @@ export const getRecognisedConstraints = (
     constraints[parsedKey] = {
       inclusion: {
         within: recognisedTestResultCodes,
-        message: `'${fhirKey}' is an unrecognised code - please use of the following codes: ${recognisedTestResultCodes}`,
+        message: `'${fhirKey}' is an unrecognised code - please use one of the following codes: ${recognisedTestResultCodes}`,
       },
     };
   }

--- a/src/models/fhir/index.ts
+++ b/src/models/fhir/index.ts
@@ -1,4 +1,5 @@
 import { parse } from "./parse";
 import { hasRequiredFields } from "./required";
+import { hasRecognisedFields } from "./recognised";
 
-export default { parse, hasRequiredFields };
+export default { parse, hasRequiredFields, hasRecognisedFields };

--- a/src/models/fhir/recognised.test.ts
+++ b/src/models/fhir/recognised.test.ts
@@ -1,0 +1,48 @@
+import { R4 } from "@ahryman40k/ts-fhir-types";
+import { pdtHealthCertV2 } from "@govtechsg/oa-schemata";
+import { DetailedCodedError } from "../../common/error";
+import fhirHelper from "./index";
+import exampleSingleTypeHealthCertWithNric from "../../../test/fixtures/v2/pdt_pcr_with_nric_unwrapped.json";
+import exampleMultiTypeHealthCertWithNric from "../../../test/fixtures/v2/pdt_pcr_ser_multi_result_unwrapped.json";
+
+const { PdtTypes } = pdtHealthCertV2;
+
+describe.only("recognised fields", () => {
+  test("should throw error if single type HealthCert has an invalid test result code", () => {
+    let thrownError;
+    const parsedFhirBundle = fhirHelper.parse(
+      exampleSingleTypeHealthCertWithNric.fhirBundle as R4.IBundle
+    );
+    parsedFhirBundle.observations[0].observation.result.code = "foobar";
+    try {
+      fhirHelper.hasRecognisedFields(PdtTypes.Pcr, parsedFhirBundle);
+    } catch (e) {
+      if (e instanceof DetailedCodedError) {
+        thrownError = `${e.title}, ${e.messageBody}`;
+      }
+    }
+    expect(thrownError).toMatchInlineSnapshot(
+      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'0.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
+    );
+  });
+
+  test("should throw error if multi type HealthCert has an invalid test result code", () => {
+    let thrownError;
+    const parsedFhirBundle = fhirHelper.parse(
+      exampleMultiTypeHealthCertWithNric.fhirBundle as R4.IBundle
+    );
+    parsedFhirBundle.observations.forEach(({ observation }) => {
+      observation.result.code = "foobar";
+    });
+    try {
+      fhirHelper.hasRecognisedFields(PdtTypes.Art, parsedFhirBundle);
+    } catch (e) {
+      if (e instanceof DetailedCodedError) {
+        thrownError = `${e.title}, ${e.messageBody}`;
+      }
+    }
+    expect(thrownError).toMatchInlineSnapshot(
+      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'0.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\",\\"'1.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
+    );
+  });
+});

--- a/src/models/fhir/recognised.test.ts
+++ b/src/models/fhir/recognised.test.ts
@@ -22,7 +22,7 @@ describe("recognised fields", () => {
       }
     }
     expect(thrownError).toMatchInlineSnapshot(
-      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'0.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
+      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'0.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use one of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
     );
   });
 
@@ -40,7 +40,7 @@ describe("recognised fields", () => {
       }
     }
     expect(thrownError).toMatchInlineSnapshot(
-      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'1.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
+      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'1.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use one of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
     );
   });
 });

--- a/src/models/fhir/recognised.test.ts
+++ b/src/models/fhir/recognised.test.ts
@@ -7,7 +7,7 @@ import exampleMultiTypeHealthCertWithNric from "../../../test/fixtures/v2/pdt_pc
 
 const { PdtTypes } = pdtHealthCertV2;
 
-describe.only("recognised fields", () => {
+describe("recognised fields", () => {
   test("should throw error if single type HealthCert has an invalid test result code", () => {
     let thrownError;
     const parsedFhirBundle = fhirHelper.parse(
@@ -31,9 +31,7 @@ describe.only("recognised fields", () => {
     const parsedFhirBundle = fhirHelper.parse(
       exampleMultiTypeHealthCertWithNric.fhirBundle as R4.IBundle
     );
-    parsedFhirBundle.observations.forEach(({ observation }) => {
-      observation.result.code = "foobar";
-    });
+    parsedFhirBundle.observations[1].observation.result.code = "foobar";
     try {
       fhirHelper.hasRecognisedFields(PdtTypes.Art, parsedFhirBundle);
     } catch (e) {
@@ -42,7 +40,7 @@ describe.only("recognised fields", () => {
       }
     }
     expect(thrownError).toMatchInlineSnapshot(
-      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'0.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\",\\"'1.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
+      `"Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: [\\"'1.Observation.valueCodeableConcept.coding[0].code' is an unrecognised code - please use of the following codes: 10828004,260385009,260373001,260415000\\"]. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38"`
     );
   });
 });

--- a/src/models/fhir/recognised.ts
+++ b/src/models/fhir/recognised.ts
@@ -1,0 +1,24 @@
+import validate from "validate.js";
+import { DocumentInvalidError } from "../../common/error";
+import { ParsedBundle } from "./types";
+import { getRecognisedConstraints, Type } from "./constraints";
+
+export const hasRecognisedFields = (type: Type, parsedBundle: ParsedBundle) => {
+  const constraints = getRecognisedConstraints(
+    type,
+    parsedBundle.observations.length
+  );
+
+  const errors = validate(parsedBundle, constraints, {
+    fullMessages: false,
+    format: "flat",
+  });
+
+  if (errors) {
+    throw new DocumentInvalidError(
+      `the following fields in fhirBundle are not recognised: ${JSON.stringify(
+        errors
+      )}. For more info, refer to the mapping table here: https://github.com/Open-Attestation/schemata/pull/38`
+    );
+  }
+};

--- a/src/models/fhir/required.ts
+++ b/src/models/fhir/required.ts
@@ -1,10 +1,13 @@
 import validate from "validate.js";
 import { DocumentInvalidError } from "../../common/error";
 import { ParsedBundle } from "./types";
-import { getConstraints, Type } from "./constraints";
+import { getRequiredConstraints, Type } from "./constraints";
 
 export const hasRequiredFields = (type: Type, parsedBundle: ParsedBundle) => {
-  const constraints = getConstraints(type, parsedBundle.observations.length);
+  const constraints = getRequiredConstraints(
+    type,
+    parsedBundle.observations.length
+  );
 
   const errors = validate(parsedBundle, constraints, {
     fullMessages: false,


### PR DESCRIPTION
## What does this PR do?
- Refactoring variables for clarity
- Introduce `hasRecognisedFields()` for test result code validation - serves as a place to add custom FHIR validations in the future (see 16d359a678878687e98aa70a031cb5ce035e0d7a onwards)
- Enable logo size validation as well (#404)

## Recognised Test Result Codes (2 sets)
### What Notarise uses
- `260385009` (Negative): https://phinvads.cdc.gov/vads/ViewCodeSystemConcept.action?oid=2.16.840.1.113883.6.96&code=260385009
- `10828004` (Positive): https://phinvads.cdc.gov/vads/ViewCodeSystemConcept.action?oid=2.16.840.1.113883.6.96&code=10828004

### What EU DCC uses
- `260415000` (Not detected): https://phinvads.cdc.gov/vads/ViewCodeSystemConcept.action?oid=2.16.840.1.113883.6.96&code=260415000
- `260373001` (Detected): https://phinvads.cdc.gov/vads/ViewCodeSystemConcept.action?oid=2.16.840.1.113883.6.96&code=260373001