### PR TITLE
Fix: EU DCC offline qr issuer country code

### DIFF
--- a/src/models/euDccCertificates/index.ts
+++ b/src/models/euDccCertificates/index.ts
@@ -62,7 +62,7 @@ const genEuDccCertificates = async (
     process.env.SIGNING_EU_QR_PRIVATE_KEY,
     ""
   );
-  const euDccGenerator = EuDccGenerator(publicKey, privateKey, euSigner.issuer);
+  const euDccGenerator = EuDccGenerator(publicKey, privateKey, "SG");
   const basicDetails: BasicDetails = {
     reference: uuid,
     issuerName: euSigner.issuer,


### PR DESCRIPTION
- Fix issuer claim setting ([context](https://gahmen.slack.com/archives/C01Q487M2RZ/p1648121359157189?thread_ts=1647996770.708299&cid=C01Q487M2RZ))
- surprisingly https://www.npmjs.com/package/@notarise-gov-sg/eu-dcc-generator is already support for setting like this