### PR TITLE
fix: 181751867 ensure 2 observation resources for multi type healthcert

### DIFF
--- a/src/models/fhir/constraints.ts
+++ b/src/models/fhir/constraints.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { pdtHealthCertV2 } from "@govtechsg/oa-schemata";
+import { isNRICValid } from "@notarise-gov-sg/sns-notify-recipients/dist/services/validateNRIC";
 import { CodedError } from "../../common/error";
 import euDccTestResultMapping from "../../static/EU-DCC-test-result.mapping.json";
 
@@ -128,6 +129,10 @@ const artGroupedFhirKeys = {
   "observations._.device.type.system": "_.Device.type.coding[0].system",
   "observations._.device.type.code": "_.Device.type.coding[0].code",
   "observations._.device.type.display": "_.Device.type.coding[0].display",
+
+  // Modality(s)
+  "observations._.observation.modality":
+    "_.Observation.note[n].{ id=MODALITY, text }",
 };
 
 /**
@@ -162,6 +167,9 @@ const pcrSerLampGroupedFhirKeys = {
     "_.Organization.contact[0].address.text",
 };
 
+/**
+ * Individual constraints of required fields for all HealthCert types
+ */
 const generateRequiredConstraints = (mapping: Record<string, string>) => {
   const allKeys = Object.keys(mapping);
   const constraints: Record<string, any> = {};
@@ -178,6 +186,9 @@ const generateRequiredConstraints = (mapping: Record<string, string>) => {
   return constraints;
 };
 
+/**
+ * Grouped constraints of required fields for all HealthCert types
+ */
 const generateRequiredGroupedConstraints = (
   mapping: Record<string, string>,
   observationCount: number
@@ -195,26 +206,6 @@ const generateRequiredGroupedConstraints = (
     });
   }
 
-  return constraints;
-};
-
-const generateArtModalityConstraints = (
-  observationCount: number
-): Record<string, any> => {
-  const constraints: Record<string, any> = {};
-  for (let i = 0; i < observationCount; i += 1) {
-    constraints[`observations.${i}.observation.modality`] = {
-      presence: {
-        message: `"_.Observation.note[n].{ id=MODALITY, text }"' is required`,
-        allowEmpty: false,
-      },
-      inclusion: {
-        within: ["Administered", "Supervised", "Remotely Supervised"],
-        message:
-          "_.Observation.note[n].text must be of one of the values ['Administered', 'Supervised', 'Remotely Supervised']",
-      },
-    };
-  }
   return constraints;
 };
 
@@ -243,7 +234,6 @@ export const getRequiredConstraints = (
         artGroupedFhirKeys,
         observationCount
       ),
-      ...generateArtModalityConstraints(observationCount),
     };
   } else if (
     type === PdtTypes.Lamp ||
@@ -274,28 +264,80 @@ export const getRequiredConstraints = (
   }
 };
 
+/**
+ * Constraints of recognised/accepted values according to HealthCert type
+ */
 export const getRecognisedConstraints = (
-  _type: Type,
+  type: Type,
   observationCount: number
 ) => {
   const constraints: Record<string, any> = {};
 
-  /* Inclusion validation: Limit to 2 sets of Test Result Codes */
+  /* 1. NRIC-FIN validation: Must produce a valid checksum */
+  constraints["patient.nricFin"] = { nricFin: { allowEmpty: true } };
+
+  /* 2. Inclusion validation: For each Observation, limit to 2 sets of Test Result Codes */
   const recognisedTestResultCodes = [
     ...Object.keys(euDccTestResultMapping),
     ...Object.values(euDccTestResultMapping),
   ];
   for (let i = 0; i < observationCount; i += 1) {
-    const k = `observations._.observation.result.code`;
-    const parsedKey = k.replace("_", i.toString());
-    const fhirKey = commonGroupedFhirKeys[k].replace("_", i.toString());
-    constraints[parsedKey] = {
+    const key = `observations._.observation.result.code`;
+    const friendlyKey = commonGroupedFhirKeys[key];
+
+    const numKey = key.replace("_", i.toString());
+    const numFriendlyKey = friendlyKey.replace("_", i.toString());
+
+    constraints[numKey] = {
       inclusion: {
         within: recognisedTestResultCodes,
-        message: `'${fhirKey}' is an unrecognised code - please use one of the following codes: ${recognisedTestResultCodes}`,
+        message: `'${numFriendlyKey}' is an unrecognised test result code - please use one of the following codes: ${recognisedTestResultCodes}`,
       },
     };
   }
 
+  /* 3. ART Modality field: Limit to "Administered", "Supervised" or "Remotely Supervised" */
+  const recongisedArtModalityValues = [
+    "Administered",
+    "Supervised",
+    "Remotely Supervised",
+  ];
+  if (type === pdtHealthCertV2.PdtTypes.Art) {
+    for (let i = 0; i < observationCount; i += 1) {
+      const key = `observations._.observation.modality`;
+      const friendlyKey = artGroupedFhirKeys[key];
+
+      const numKey = key.replace("_", i.toString());
+      const numFriendlyKey = friendlyKey.replace("_", i.toString());
+
+      constraints[numKey] = {
+        inclusion: {
+          within: recongisedArtModalityValues,
+          message: `'${numFriendlyKey}' is an unrecognised modality value - please use one of the following values: ${recongisedArtModalityValues}`,
+        },
+      };
+    }
+  }
+
   return constraints;
+};
+
+/**
+ * Introduce custom NRIC-FIN validator
+ * Used by getRecognisedConstraints() in "src/models/fhir/constraints.ts"
+ */
+export const customNricFinValidation = (
+  value: unknown,
+  options: { allowEmpty: boolean }
+) => {
+  if (options.allowEmpty && !value) {
+    return null; // Pass
+  }
+
+  const friendlyKey = `Patient.identifier[1].{ id=NRIC-FIN, value }`;
+  if (typeof value !== "string")
+    return `'${friendlyKey}' value should be a valid string type`;
+  else if (!isNRICValid(value))
+    return `'${friendlyKey}' value has an invalid NRIC-FIN checksum`;
+  else return null; // Pass
 };

--- a/src/models/fhir/recognised.ts
+++ b/src/models/fhir/recognised.ts
@@ -1,14 +1,19 @@
 import validate from "validate.js";
-import { isNRICValid } from "@notarise-gov-sg/sns-notify-recipients/dist/services/validateNRIC";
 import { CodedError } from "../../common/error";
 import { ParsedBundle } from "./types";
-import { getRecognisedConstraints, Type } from "./constraints";
+import {
+  getRecognisedConstraints,
+  customNricFinValidation,
+  Type,
+} from "./constraints";
 
 export const hasRecognisedFields = (type: Type, parsedBundle: ParsedBundle) => {
   const constraints = getRecognisedConstraints(
     type,
     parsedBundle.observations.length
   );
+
+  validate.validators.nricFin = customNricFinValidation;
 
   const errors = validate(parsedBundle, constraints, {
     fullMessages: false,
@@ -21,17 +26,6 @@ export const hasRecognisedFields = (type: Type, parsedBundle: ParsedBundle) => {
       `Submitted HealthCert is invalid, the following fields in fhirBundle are not recognised: ${JSON.stringify(
         errors
       )}. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki`
-    );
-  }
-
-  // validate nric/fin checksum only if provided in fhirBundle
-  if (
-    parsedBundle.patient.nricFin &&
-    !isNRICValid(parsedBundle.patient.nricFin)
-  ) {
-    throw new CodedError(
-      "INVALID_DOCUMENT",
-      `Submitted HealthCert is invalid, the patient NRIC-FIN value in fhirBundle has an invalid checksum.`
     );
   }
 };

--- a/src/models/fhir/required.test.ts
+++ b/src/models/fhir/required.test.ts
@@ -7,7 +7,7 @@ import exampleArtHealthCertWithNric from "../../../test/fixtures/v2/pdt_art_with
 
 const { PdtTypes } = pdtHealthCertV2;
 
-describe("validatePCRHealthCertData", () => {
+describe("PCR: Required values", () => {
   test("should pass for valid PCR healthcert", () => {
     const parseFhirBundle = fhirHelper.parse(
       examplePcrHealthCertWithNric.fhirBundle as R4.IBundle
@@ -24,7 +24,7 @@ describe("validatePCRHealthCertData", () => {
       fhirHelper.hasRequiredFields(PdtTypes.Ser, parseFhirBundle)
     ).not.toThrow();
   });
-  test("should throw error if PCR healthcert not have Accredited Laboratory", () => {
+  test("should throw error if PCR healthcert has missing Accredited Laboratory", () => {
     let thrownError;
     const parseFhirBundle = fhirHelper.parse(
       exampleArtHealthCertWithNric.fhirBundle as R4.IBundle
@@ -41,7 +41,8 @@ describe("validatePCRHealthCertData", () => {
     );
   });
 });
-describe("validateARTHealthCertData", () => {
+
+describe("ART: Required values", () => {
   test("should pass for valid ART healthcert", () => {
     const parseFhirBundle = fhirHelper.parse(
       exampleArtHealthCertWithNric.fhirBundle as R4.IBundle
@@ -50,69 +51,42 @@ describe("validateARTHealthCertData", () => {
       fhirHelper.hasRequiredFields(PdtTypes.Art, parseFhirBundle)
     ).not.toThrow();
   });
-
-  test("should throw error if ART healthcert lacks Observation.modality", () => {
+  test("should throw error if ART healthcert has missing Modality", () => {
     let thrownError;
-    const malformedHealthCert = examplePcrHealthCertWithNric;
 
-    const parseFhirBundle = fhirHelper.parse(
-      malformedHealthCert.fhirBundle as R4.IBundle
+    const parsedFhirBundle = fhirHelper.parse(
+      exampleArtHealthCertWithNric.fhirBundle as R4.IBundle
     );
+    delete parsedFhirBundle.observations[0].observation.modality;
 
     try {
-      fhirHelper.hasRequiredFields(PdtTypes.Art, parseFhirBundle);
+      fhirHelper.hasRequiredFields(PdtTypes.Art, parsedFhirBundle);
     } catch (e) {
       if (e instanceof CodedError) {
         thrownError = `${e.message}`;
       }
     }
     expect(thrownError).toMatchInlineSnapshot(
-      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'0.Specimen.subject.{ type=Device, reference }' is required\\",\\"'0.Device.type.coding[0].system' is required\\",\\"'0.Device.type.coding[0].code' is required\\",\\"'0.Device.type.coding[0].display' is required\\",\\"\\\\\\"_.Observation.note[n].{ id=MODALITY, text }\\\\\\"' is required\\"]. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki"`
+      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'0.Observation.note[n].{ id=MODALITY, text }' is required\\"]. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki"`
     );
   });
-
-  test("should throw error if ART healthcert has unrecognised modality", () => {
+  test("should throw error if ART healthcert has missing Device", () => {
     let thrownError;
-    const malformedHealthCert = exampleArtHealthCertWithNric;
-    const entry = malformedHealthCert.fhirBundle.entry.find(
-      (ent) => ent.resource.resourceType === "Observation"
-    );
-    if (entry != null && entry.resource != null && entry.resource.note) {
-      entry.resource.note[0].text = "UNKNOWN Modality";
-    }
 
-    const parseFhirBundle = fhirHelper.parse(
-      malformedHealthCert.fhirBundle as R4.IBundle
+    const parsedFhirBundle = fhirHelper.parse(
+      exampleArtHealthCertWithNric.fhirBundle as R4.IBundle
     );
+    delete parsedFhirBundle.observations[0].device;
 
     try {
-      fhirHelper.hasRequiredFields(PdtTypes.Art, parseFhirBundle);
+      fhirHelper.hasRequiredFields(PdtTypes.Art, parsedFhirBundle);
     } catch (e) {
       if (e instanceof CodedError) {
         thrownError = `${e.message}`;
       }
     }
     expect(thrownError).toMatchInlineSnapshot(
-      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"_.Observation.note[n].text must be of one of the values ['Administered', 'Supervised', 'Remotely Supervised']\\"]. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki"`
-    );
-  });
-
-  test("should throw error if ART healthcert not have device identifier", () => {
-    let thrownError;
-    const malformedHealthCert = exampleArtHealthCertWithNric as any;
-    malformedHealthCert.fhirBundle.entry.pop();
-    const parseFhirBundle = fhirHelper.parse(
-      malformedHealthCert.fhirBundle as R4.IBundle
-    );
-    try {
-      fhirHelper.hasRequiredFields(PdtTypes.Art, parseFhirBundle);
-    } catch (e) {
-      if (e instanceof CodedError) {
-        thrownError = `${e.message}`;
-      }
-    }
-    expect(thrownError).toMatchInlineSnapshot(
-      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'0.Device.type.coding[0].system' is required\\",\\"'0.Device.type.coding[0].code' is required\\",\\"'0.Device.type.coding[0].display' is required\\",\\"_.Observation.note[n].text must be of one of the values ['Administered', 'Supervised', 'Remotely Supervised']\\"]. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki"`
+      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'0.Device.type.coding[0].system' is required\\",\\"'0.Device.type.coding[0].code' is required\\",\\"'0.Device.type.coding[0].display' is required\\"]. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki"`
     );
   });
 });

--- a/src/models/fhir/required.test.ts
+++ b/src/models/fhir/required.test.ts
@@ -4,33 +4,34 @@ import { CodedError } from "../../common/error";
 import fhirHelper from "./index";
 import examplePcrHealthCertWithNric from "../../../test/fixtures/v2/pdt_pcr_with_nric_unwrapped.json";
 import exampleArtHealthCertWithNric from "../../../test/fixtures/v2/pdt_art_with_nric_unwrapped.json";
+import exampleMultiTypeHealthCertWithNric from "../../../test/fixtures/v2/pdt_pcr_ser_multi_result_unwrapped.json";
 
 const { PdtTypes } = pdtHealthCertV2;
 
 describe("PCR: Required values", () => {
   test("should pass for valid PCR healthcert", () => {
-    const parseFhirBundle = fhirHelper.parse(
+    const parsedFhirBundle = fhirHelper.parse(
       examplePcrHealthCertWithNric.fhirBundle as R4.IBundle
     );
     expect(() =>
-      fhirHelper.hasRequiredFields(PdtTypes.Pcr, parseFhirBundle)
+      fhirHelper.hasRequiredFields(PdtTypes.Pcr, parsedFhirBundle)
     ).not.toThrow();
   });
   test("should pass for valid SER healthcert", () => {
-    const parseFhirBundle = fhirHelper.parse(
+    const parsedFhirBundle = fhirHelper.parse(
       examplePcrHealthCertWithNric.fhirBundle as R4.IBundle
     );
     expect(() =>
-      fhirHelper.hasRequiredFields(PdtTypes.Ser, parseFhirBundle)
+      fhirHelper.hasRequiredFields(PdtTypes.Ser, parsedFhirBundle)
     ).not.toThrow();
   });
   test("should throw error if PCR healthcert has missing Accredited Laboratory", () => {
     let thrownError;
-    const parseFhirBundle = fhirHelper.parse(
+    const parsedFhirBundle = fhirHelper.parse(
       exampleArtHealthCertWithNric.fhirBundle as R4.IBundle
     );
     try {
-      fhirHelper.hasRequiredFields(PdtTypes.Pcr, parseFhirBundle);
+      fhirHelper.hasRequiredFields(PdtTypes.Pcr, parsedFhirBundle);
     } catch (e) {
       if (e instanceof CodedError) {
         thrownError = `${e.message}`;
@@ -44,11 +45,11 @@ describe("PCR: Required values", () => {
 
 describe("ART: Required values", () => {
   test("should pass for valid ART healthcert", () => {
-    const parseFhirBundle = fhirHelper.parse(
+    const parsedFhirBundle = fhirHelper.parse(
       exampleArtHealthCertWithNric.fhirBundle as R4.IBundle
     );
     expect(() =>
-      fhirHelper.hasRequiredFields(PdtTypes.Art, parseFhirBundle)
+      fhirHelper.hasRequiredFields(PdtTypes.Art, parsedFhirBundle)
     ).not.toThrow();
   });
   test("should throw error if ART healthcert has missing Modality", () => {
@@ -87,6 +88,43 @@ describe("ART: Required values", () => {
     }
     expect(thrownError).toMatchInlineSnapshot(
       `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'0.Device.type.coding[0].system' is required\\",\\"'0.Device.type.coding[0].code' is required\\",\\"'0.Device.type.coding[0].display' is required\\"]. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki"`
+    );
+  });
+});
+
+describe("Multi type: Required values", () => {
+  test("should pass for valid PCR+SER healthcert", () => {
+    const parsedFhirBundle = fhirHelper.parse(
+      exampleMultiTypeHealthCertWithNric.fhirBundle as R4.IBundle
+    );
+    expect(() =>
+      fhirHelper.hasRequiredFields(
+        [PdtTypes.Pcr, PdtTypes.Ser],
+        parsedFhirBundle
+      )
+    ).not.toThrow();
+  });
+
+  test("should throw error for invalid PCR+SER healthcert with only 1 observation", () => {
+    let thrownError;
+
+    const parsedFhirBundle = fhirHelper.parse(
+      exampleMultiTypeHealthCertWithNric.fhirBundle as R4.IBundle
+    );
+    parsedFhirBundle.observations.pop();
+
+    try {
+      fhirHelper.hasRequiredFields(
+        [PdtTypes.Pcr, PdtTypes.Ser],
+        parsedFhirBundle
+      );
+    } catch (e) {
+      if (e instanceof CodedError) {
+        thrownError = `${e.message}`;
+      }
+    }
+    expect(thrownError).toMatchInlineSnapshot(
+      `"Submitted HealthCert is invalid, the following required fields in fhirBundle are missing: [\\"'1.Observation.specimen.{ type=Specimen, reference }' is required\\",\\"'1.Observation.performer[0].{ type=Practitioner, reference }' is required\\",\\"'1.Observation.performer[1].{ id=LHP, type=Organization, reference }' is required\\",\\"'1.Observation.identifier[id=ACSN].value' is required\\",\\"'1.Observation.category[0].coding[0].system' is required\\",\\"'1.Observation.category[0].coding[0].code' is required\\",\\"'1.Observation.category[0].coding[0].display' is required\\",\\"'1.Observation.code.coding[0].system' is required\\",\\"'1.Observation.code.coding[0].code' is required\\",\\"'1.Observation.code.coding[0].display' is required\\",\\"'1.Observation.valueCodeableConcept.coding[0].system' is required\\",\\"'1.Observation.valueCodeableConcept.coding[0].code' is required\\",\\"'1.Observation.valueCodeableConcept.coding[0].display' is required\\",\\"'1.Observation.effectiveDateTime' is required\\",\\"'' is required\\",\\"'1.Specimen.type.coding[0].system' is required\\",\\"'1.Specimen.type.coding[0].code' is required\\",\\"'1.Specimen.type.coding[0].display' is required\\",\\"'1.Specimen.collection.collectedDateTime' is required\\",\\"'1.Practitioner.name[0].text' is required\\",\\"'1.Practitioner.qualification[0].identifier[0].{ id=MCR, value }' is required\\",\\"'1.Practitioner.qualification[0].issuer.{ type=Organization, reference }' is required\\",\\"'1.Organization.name' is required\\",\\"'1.Organization.type[0].coding[0].system' is required\\",\\"'1.Organization.type[0].coding[0].code' is required\\",\\"'1.Organization.type[0].coding[0].display' is required\\",\\"'1.Organization.contact[0].telecom[0].{ system=url, value }' is required\\",\\"'1.Organization.contact[0].telecom[1].{ system=phone, value }' is required\\",\\"'1.Organization.contact[0].address.type' is required\\",\\"'1.Organization.contact[0].address.use' is required\\",\\"'1.Organization.contact[0].address.text' is required\\",\\"'Observation.performer[2].{ id=AL, type=Organization, reference }' is required\\"]. For more info, refer to the documentation here: https://github.com/Notarise-gov-sg/api-notarise-healthcerts/wiki"`
     );
   });
 });

--- a/src/models/fhir/required.ts
+++ b/src/models/fhir/required.ts
@@ -4,10 +4,7 @@ import { ParsedBundle } from "./types";
 import { getRequiredConstraints, Type } from "./constraints";
 
 export const hasRequiredFields = (type: Type, parsedBundle: ParsedBundle) => {
-  const constraints = getRequiredConstraints(
-    type,
-    parsedBundle.observations.length
-  );
+  const constraints = getRequiredConstraints(type);
 
   const errors = validate(parsedBundle, constraints, {
     fullMessages: false,


### PR DESCRIPTION
**What does this PR do?**
- Refactor: Re-organise required and recognised constraints
- Validate to ensure there are 2 Observation resources for multi type HealthCerts