### PR TITLE
feat: set oscp responder revocation

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -89,6 +89,7 @@ functions:
       SIGNING_DID: ${self:custom.${self:custom.envSource}.SIGNING_DID}
       SIGNING_DID_KEY: ${self:custom.${self:custom.envSource}.SIGNING_DID_KEY}
       SIGNING_DID_PRIVATE_KEY: ${self:custom.${self:custom.envSource}.SIGNING_DID_PRIVATE_KEY}
+      REVOCATION_OCSP: ${self:custom.${self:custom.envSource}.REVOCATION_OCSP}
       TRANSIENT_STORAGE_URL: ${self:custom.${self:custom.envSource}.TRANSIENT_STORAGE_URL}
       TRANSIENT_STORAGE_API_KEY: ${self:custom.${self:custom.envSource}.TRANSIENT_STORAGE_API_KEY}
       NOTIFICATION_ENABLED: ${self:custom.${self:custom.envSource}.NOTIFICATION_ENABLED}
@@ -141,7 +142,7 @@ custom:
           - "notarize-${self:custom.subnetEnvName.${self:provider.stage}, self:custom.subnetEnvName.other}-application-private-*"
     securityGroups:
       - names:
-        - "default-application-vpc-*"
+          - "default-application-vpc-*"
   subnetEnvName:
     stg: "stg"
     production: "prd"
@@ -173,6 +174,7 @@ custom:
     SIGNING_DID: ${ssm:/serverless/api-notarise-healthcerts/SIGNING_DID~true, ""}
     SIGNING_DID_KEY: ${ssm:/serverless/api-notarise-healthcerts/SIGNING_DID_KEY~true, ""}
     SIGNING_DID_PRIVATE_KEY: ${ssm:/serverless/api-notarise-healthcerts/SIGNING_DID_PRIVATE_KEY~true, ""}
+    REVOCATION_OCSP: ${ssm:/serverless/api-notarise-healthcerts/REVOCATION_OCSP, ""}
     TRANSIENT_STORAGE_URL: ${ssm:/serverless/api-notarise-healthcerts/TRANSIENT_STORAGE_URL, ""}
     TRANSIENT_STORAGE_API_KEY: ${ssm:/serverless/api-notarise-healthcerts/TRANSIENT_STORAGE_API_KEY~true, ""}
     NOTIFICATION_ENABLED: ${ssm:/serverless/api-notarise-healthcerts/NOTIFICATION_ENABLED, ""}
@@ -198,6 +200,7 @@ custom:
     SIGNING_DID: ${env:SIGNING_DID, ""}
     SIGNING_DID_KEY: ${env:SIGNING_DID_KEY, ""}
     SIGNING_DID_PRIVATE_KEY: ${env:SIGNING_DID_PRIVATE_KEY, ""}
+    REVOCATION_OCSP: ${env:REVOCATION_OCSP, ""}
     TRANSIENT_STORAGE_URL: ${env:TRANSIENT_STORAGE_URL, ""}
     TRANSIENT_STORAGE_API_KEY: ${env:TRANSIENT_STORAGE_API_KEY, ""}
     NOTIFICATION_ENABLED: ${env:NOTIFICATION_ENABLED, ""}
@@ -228,9 +231,9 @@ custom:
   slicWatchEnable:
     production: true
     stg: false
-    other:  false
+    other: false
   slicWatch:
-    topicArn: "arn:aws:sns:${self:provider.region}:${self:custom.accountId}:sns-slack-notifier" 
+    topicArn: "arn:aws:sns:${self:provider.region}:${self:custom.accountId}:sns-slack-notifier"
     enabled: ${self:custom.slicWatchEnable.${self:provider.stage}, self:custom.slicWatchEnable.other}
     alarms:
       enabled: true

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,7 @@ const generateConfig = () => ({
   isOffline: isTruthy(process.env.IS_OFFLINE),
   transientStorage: getTransientStorageConfig(),
   authorizedIssuers: getAuthorizedIssuersApiConfig(),
+  revocationOcsp: getDefaultIfUndefined(process.env.REVOCATION_OCSP, ""),
   didSigner: getDidSigner(),
   euSigner: getEuSigner(),
   gpaySigner: getGPayCovidCardSigner(),

--- a/src/models/notarizedHealthCertV2/createNotarizedHealthCert/createUnwrappedHealthCert.ts
+++ b/src/models/notarizedHealthCertV2/createNotarizedHealthCert/createUnwrappedHealthCert.ts
@@ -5,7 +5,7 @@ import { ParsedBundle } from "../../fhir/types";
 import { config } from "../../../config";
 import { PDTHealthCertV2, EndorsedPDTHealthCertV2 } from "../../../types";
 
-const { didSigner } = config;
+const { didSigner, revocationOcsp } = config;
 
 export const createUnwrappedDocument = (
   certificate: WrappedDocument<PDTHealthCertV2>,
@@ -50,9 +50,14 @@ export const createUnwrappedDocument = (
     {
       name: didSigner.name,
       id: didSigner.id,
-      revocation: {
-        type: v2.RevocationType.None,
-      },
+      revocation: revocationOcsp
+        ? {
+            type: v2.RevocationType.OcspResponder,
+            location: revocationOcsp,
+          }
+        : {
+            type: v2.RevocationType.None,
+          },
       identityProof: {
         type: v2.IdentityProofType.DNSDid,
         location: didSigner.dns,


### PR DESCRIPTION
**What does this PR do?**
If `process.env.REVOCATION_OCSP` is supplied, set revocation type to OCSP and specify location using the given value.