### PR TITLE
chore: 182485936 make ACSN optional for LAMP HealthCerts

### DIFF
--- a/src/models/fhir/constraints.ts
+++ b/src/models/fhir/constraints.ts
@@ -165,6 +165,15 @@ const pcrSerGroupedFhirKeys = {
     "_.Organization.contact[0].address.text",
 };
 
+/**
+ * LAMP constraints:
+ * To convert parsed format -> original FHIR Bundle format (to aid in custom error message)
+ */
+const lampGroupedFhirKeys: Partial<typeof commonGroupedFhirKeys> = {
+  ...commonGroupedFhirKeys,
+};
+delete lampGroupedFhirKeys["observations._.observation.acsn"];
+
 const enumerateKeys = (key: string, friendlyKey: string, index: number) => ({
   numKey: key.replace("_", index.toString()),
   numFriendlyKey: friendlyKey.replace("_", index.toString()),
@@ -256,7 +265,7 @@ export const getRequiredConstraints = (type: Type) => {
      */
     return {
       ...generateRequiredConstraints(commonFhirKeys),
-      ...generateRequiredGroupedConstraints(commonGroupedFhirKeys, 1),
+      ...generateRequiredGroupedConstraints(lampGroupedFhirKeys, 1),
     };
   } else {
     /**

--- a/test/fixtures/v2/pdt_lamp_unwrapped.json
+++ b/test/fixtures/v2/pdt_lamp_unwrapped.json
@@ -1,278 +1,231 @@
 {
-    "id": "76caf3f9-5591-4ef1-b756-1cb47a76dede",
-    "version": "pdt-healthcert-v2.0",
-    "type": "LAMP",
-    "validFrom": "2021-08-24T04:22:36.062Z",
-    "fhirVersion": "4.0.1",
-    "fhirBundle": {
-        "resourceType": "Bundle",
-        "type": "collection",
-        "entry": [
+  "id": "76caf3f9-5591-4ef1-b756-1cb47a76dede",
+  "version": "pdt-healthcert-v2.0",
+  "type": "LAMP",
+  "validFrom": "2021-08-24T04:22:36.062Z",
+  "fhirVersion": "4.0.1",
+  "fhirBundle": {
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
+        "resource": {
+          "resourceType": "Patient",
+          "extension": [
             {
-                "fullUrl": "urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
-                "resource": {
-                    "resourceType": "Patient",
-                    "extension": [
-                        {
-                            "url": "http://hl7.org/fhir/StructureDefinition/patient-nationality",
-                            "extension": [
-                                {
-                                    "url": "code",
-                                    "valueCodeableConcept": {
-                                        "text": "Patient Nationality",
-                                        "coding": [
-                                            {
-                                                "system": "urn:iso:std:iso:3166",
-                                                "code": "SG"
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    ],
-                    "identifier": [
-                        {
-                            "id": "PPN",
-                            "type": {
-                                "coding": [
-                                    {
-                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                                        "code": "PPN",
-                                        "display": "Passport Number"
-                                    }
-                                ]
-                            },
-                            "value": "E7831177G"
-                        },
-                        {
-                            "id": "NRIC-FIN",
-                            "value": "S3001470G"
-                        }
-                    ],
-                    "name": [
-                        {
-                            "text": "Tan Chen Chen"
-                        }
-                    ],
-                    "gender": "female",
-                    "birthDate": "1990-01-15"
-                }
-            },
-            {
-                "fullUrl": "urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
-                "resource": {
-                    "resourceType": "Observation",
-                    "specimen": {
-                        "type": "Specimen",
-                        "reference": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae"
-                    },
-                    "performer": [
-                        {
-                            "type": "Practitioner",
-                            "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
-                        },
-                        {
-                            "id": "LHP",
-                            "type": "Organization",
-                            "reference": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1"
-                        }
-                    ],
-                    "identifier": [
-                        {
-                            "id": "ACSN",
-                            "type": {
-                                "coding": [
-                                    {
-                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                                        "code": "ACSN",
-                                        "display": "Accession ID"
-                                    }
-                                ]
-                            },
-                            "value": "123456789"
-                        }
-                    ],
-                    "category": [
-                        {
-                            "coding": [
-                                {
-                                    "system": "http://snomed.info/sct",
-                                    "code": "840539006",
-                                    "display": "COVID-19"
-                                }
-                            ]
-                        }
-                    ],
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://loinc.org",
-                                "code": "96986-5",
-                                "display": "SARS-CoV-2 (COVID-19) N gene [Presence] in Nose by NAA with non-probe detection"
-                            }
-                        ]
-                    },
-                    "valueCodeableConcept": {
-                        "coding": [
-                            {
-                                "system": "http://snomed.info/sct",
-                                "code": "260385009",
-                                "display": "Negative"
-                            }
-                        ]
-                    },
-                    "effectiveDateTime": "2020-09-28T06:15:00Z",
-                    "status": "final"
-                }
-            },
-            {
-                "fullUrl": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
-                "resource": {
-                    "resourceType": "Specimen",
-                    "type": {
-                        "coding": [
-                            {
-                                "system": "http://snomed.info/sct",
-                                "code": "697989009",
-                                "display": "Anterior Nares swab"
-                            }
-                        ]
-                    },
-                    "collection": {
-                        "collectedDateTime": "2020-09-27T06:15:00Z"
-                    }
-                }
-            },
-            {
-                "fullUrl": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
-                "resource": {
-                    "resourceType": "Practitioner",
-                    "name": [
-                        {
-                            "text": "Dr Michael Lim"
-                        }
-                    ],
-                    "qualification": [
-                        {
-                            "code": {
-                                "coding": [
-                                    {
-                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                                        "code": "MCR",
-                                        "display": "Practitioner Medicare number"
-                                    }
-                                ]
-                            },
-                            "identifier": [
-                                {
-                                    "id": "MCR",
-                                    "value": "123456"
-                                }
-                            ],
-                            "issuer": {
-                                "type": "Organization",
-                                "reference": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
-                            }
-                        }
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-nationality",
+              "extension": [
+                {
+                  "url": "code",
+                  "valueCodeableConcept": {
+                    "text": "Patient Nationality",
+                    "coding": [
+                      { "system": "urn:iso:std:iso:3166", "code": "SG" }
                     ]
+                  }
                 }
-            },
-            {
-                "fullUrl": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
-                "resource": {
-                    "resourceType": "Organization",
-                    "name": "Ministry of Health (MOH)",
-                    "type": [
-                        {
-                            "coding": [
-                                {
-                                    "system": "http://terminology.hl7.org/CodeSystem/organization-type",
-                                    "code": "govt",
-                                    "display": "Government"
-                                }
-                            ]
-                        }
-                    ],
-                    "contact": [
-                        {
-                            "telecom": [
-                                {
-                                    "system": "url",
-                                    "value": "https://www.moh.gov.sg"
-                                },
-                                {
-                                    "system": "phone",
-                                    "value": "+6563259220"
-                                }
-                            ],
-                            "address": {
-                                "type": "physical",
-                                "use": "work",
-                                "text": "Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "fullUrl": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
-                "resource": {
-                    "resourceType": "Organization",
-                    "name": "MacRitchie Medical Clinic",
-                    "type": [
-                        {
-                            "coding": [
-                                {
-                                    "system": "http://terminology.hl7.org/CodeSystem/organization-type",
-                                    "code": "prov",
-                                    "display": "Healthcare Provider"
-                                }
-                            ],
-                            "text": "Licensed Healthcare Provider"
-                        }
-                    ],
-                    "contact": [
-                        {
-                            "telecom": [
-                                {
-                                    "system": "url",
-                                    "value": "https://www.macritchieclinic.com.sg"
-                                },
-                                {
-                                    "system": "phone",
-                                    "value": "+6561234567"
-                                }
-                            ],
-                            "address": {
-                                "type": "physical",
-                                "use": "work",
-                                "text": "MacRitchie Hospital, Thomson Road, Singapore 123000"
-                            }
-                        }
-                    ]
-                }
+              ]
             }
-        ]
-    },
-    "logo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAADICAMAAAApx+PaAAAAM1BMVEUAAADMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzeCmiAAAAAEHRSTlMAQL+A7xAgn2DP3zBwr1CPEl+I/QAABwdJREFUeNrsnd122yoQRvkHISHN+z/tyUk9oTECQ1bTBc23byNs0B5GIDARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAk+Ik+Idx4g5N4B9GQ/rPA9J/IPfSgwL/MEEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwP5ZPoP5r7FJKAf7cufBihPNSkX5hlA9u+DsP7dX/JK1P2VPiSIoebErLwVh5Zx+8C1Y22YtP0Fpf6hdea+mq1Wlixfej6RcDxj09swXbbeBQpijug20aj/SE8bvo5hEuavAuSKpQfJxTG91gUrCV6jSQE0oPke4wuke705EqpLNWxtMtSk4jvXGld+tLlxvVMNnakD7mEndYTVWSnV860WUXl34RMy7BempyGzN7pAbmXEA6bfvK0u32uTFKKVM0r0Yw1MTcFvp8iVLPD0+9gHQy+7rSf3eejp2HuFcsmldiEz0FzKXfSRw3qe08Xqd9dP6QKONnku4lG3NSb/RBtKtKt1ttdBJiYb2VI7brc7tc8IYotJzHUB0c+O+T3rTQuLKsZRqpzkTS7dZI4vo+qJndEGO8Ezecyjac6/ITN2KOWaULIT/aLdeUnqpdi7VW2+Kyc29FL3s7e3hi5LTSheWWpyWlH4XzmvWjniOiFN3YWDivWI92Wuk5ct2C0p3Jzl9YN66WI5IV/VyF86r1a17pH5UMC0pX/DwXVU524Ks5YgDZmL4zGz1w80p33Pj1pMvci+tc2cFIjmhH2dWVfuaVLuLjy9eTzgqOrqewv0vum/1KR4+2a6Dh5pXO7V9O+s4KRJPADuxNjtjFCCk/CltEzgfzSterSvdZQZeDoyyqxQguR1lXmBlI/9PSebZpbOe8bivt2bFK9YaK4eHe7NLNatLP3qGYLfL71RoMvB6Xu96J3TWt9LToQM5zm8YfxbHIESPZXXW/tovTSo+PqFxNeswZqjO/X09OvBgi9OcHw7llUukcv+di0rneqf99uXoKglMMwall7x/my0mlP5piVnv3fuZ+193xnpTYLz3SjejPLXpO6TtXbzXpfIUceJHmPsXAJsbI+aL7fvsppVsOX7uadJ9FvuT63PxsZAQ3UMxygLyWvsk6/luku40fb8ttolDFFb1ZQQ6/mRkv1iW9i1J6C/1aejAcvQPVmUt6FB2cn26JzDO4TsaLcWeaTbo7In04X08696XxTnrkmzGCHimmJpLuNaPi71f+KOkte5IK9OrS74ingPSfJd1oISD9Z0m/hPhB0o+/Ld3MMGUrSU68s9yUzXSO3suhW+Bh+Jj0oyz2snZqgpczd5iwpvRvmKfXpY/P0yeSfsgHOhliwtLS7cBSiR1aZFP30q+Bt3fXbK9hQ2Tr+4rSc+8dflXCO2l6pY+PIs5pF1xs4kmbXVB6z0JWRRdH+6B0w8VeoydeWlV84xaULnvX08vEzNn+HJOu+tfT1cSbKPLewvWkc/c1/Yts4SlJ+DHpunsF3069XSrw7VhQel4gHN3QuHO8jEk/O8cC+Uo/pXR+vG0LSn/ZXxlXyIoc60PSheldwvdzb4HW3I71pO/0wHYqOIp8v41JT52TNjf5jx24fmE96WLrG7/bsoM6ehCGpJ8s0/ZV3k8qnTOdX1B66HOgb4b5KRftl54fC7ovyvZZpXt6Jy4o3ZqedOvMTdslPUhD0rlWxvVMFtS0P1UOnPvWk84Xdb0DIXW/kHiMSLem7rMMKDmt9J0HmgtK/3Bg7GhgOGLCgPT8afp1pdTEx4886ngtKF2c9OpsgVDbOKCJOQaki+1VrFi+wriJpfNa/orShcrW286jLYsyyfZLl8SEtnM65j1SLH+wXVG6jc0DYI986FujKJnQLV0c1Mrw7sO5n/fwwDfkoj9gfD4ozhyFAUVMqBRlYrCd0oUnRrkiyEzOPFNLFzTzT5VlBXd3Om8ozkBtOOdDPZkU9k9/PCpLkHarnZUfIhXOv0/6ISv0SOcvj/1b9tzfkN5G3x7ebdIh34WfF6tpDrrYK6PUpd/4fJS3bpXartOJN+SRDBXOv0l6m6EzZ1z35lw9k3RO01WMFBU4H4+21lMbb8Xs0vlvYVHp3PUqKCcaODUsnbNLSR5cTC+dZ+ppVelCnKa117eNTNQkSVFiU2tP+QrSOVvZZaULqwvtPCh/jdMb3RN99QOkojv8LsQS0k/O7+tKf+NMT96NP0UvLvinRm9Jn24wVrbDCbGIdF4xVBNJ/xJSe6Ueo/Bj/9I/7Dy0PvrnJy5opSIRRZX0aQUAAPzX3h3UAACAQAx7YAD/anFBCNdamIABAAAAAAAAAAAAAAAAAAAAAAAAAADAmmoeK9HziB5I9EBXnx8AAAAAAAAAALBmAIZKmzWInxyOAAAAAElFTkSuQmCC",
-    "issuers": [
-        {
-            "id": "did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830",
-            "revocation": {
-                "type": "NONE"
+          ],
+          "identifier": [
+            {
+              "id": "PPN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "PPN",
+                    "display": "Passport Number"
+                  }
+                ]
+              },
+              "value": "E7831177G"
             },
-            "name": "SAMPLE CLINIC",
-            "identityProof": {
-                "type": "DNS-DID",
-                "location": "donotverify.testing.verify.gov.sg",
-                "key": "did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830#controller"
-            }
+            { "id": "NRIC-FIN", "value": "S3001470G" }
+          ],
+          "name": [{ "text": "Tan Chen Chen" }],
+          "gender": "female",
+          "birthDate": "1990-01-15"
         }
-    ],
-    "$template": {
-        "name": "HEALTH_CERT",
-        "type": "EMBEDDED_RENDERER",
-        "url": "https://healthcert.renderer.moh.gov.sg/"
+      },
+      {
+        "fullUrl": "urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
+        "resource": {
+          "resourceType": "Observation",
+          "specimen": {
+            "type": "Specimen",
+            "reference": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae"
+          },
+          "performer": [
+            {
+              "type": "Practitioner",
+              "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+            },
+            {
+              "id": "LHP",
+              "type": "Organization",
+              "reference": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1"
+            }
+          ],
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "840539006",
+                  "display": "COVID-19"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "96986-5",
+                "display": "SARS-CoV-2 (COVID-19) N gene [Presence] in Nose by NAA with non-probe detection"
+              }
+            ]
+          },
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative"
+              }
+            ]
+          },
+          "effectiveDateTime": "2020-09-28T06:15:00Z",
+          "status": "final"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
+        "resource": {
+          "resourceType": "Specimen",
+          "type": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "697989009",
+                "display": "Anterior Nares swab"
+              }
+            ]
+          },
+          "collection": { "collectedDateTime": "2020-09-27T06:15:00Z" }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
+        "resource": {
+          "resourceType": "Practitioner",
+          "name": [{ "text": "Dr Michael Lim" }],
+          "qualification": [
+            {
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "MCR",
+                    "display": "Practitioner Medicare number"
+                  }
+                ]
+              },
+              "identifier": [{ "id": "MCR", "value": "123456" }],
+              "issuer": {
+                "type": "Organization",
+                "reference": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "Ministry of Health (MOH)",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "govt",
+                  "display": "Government"
+                }
+              ]
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                { "system": "url", "value": "https://www.moh.gov.sg" },
+                { "system": "phone", "value": "+6563259220" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Medical Clinic",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Licensed Healthcare Provider"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                {
+                  "system": "url",
+                  "value": "https://www.macritchieclinic.com.sg"
+                },
+                { "system": "phone", "value": "+6561234567" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "MacRitchie Hospital, Thomson Road, Singapore 123000"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "logo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAADICAMAAAApx+PaAAAAM1BMVEUAAADMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzeCmiAAAAAEHRSTlMAQL+A7xAgn2DP3zBwr1CPEl+I/QAABwdJREFUeNrsnd122yoQRvkHISHN+z/tyUk9oTECQ1bTBc23byNs0B5GIDARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAk+Ik+Idx4g5N4B9GQ/rPA9J/IPfSgwL/MEEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwP5ZPoP5r7FJKAf7cufBihPNSkX5hlA9u+DsP7dX/JK1P2VPiSIoebErLwVh5Zx+8C1Y22YtP0Fpf6hdea+mq1Wlixfej6RcDxj09swXbbeBQpijug20aj/SE8bvo5hEuavAuSKpQfJxTG91gUrCV6jSQE0oPke4wuke705EqpLNWxtMtSk4jvXGld+tLlxvVMNnakD7mEndYTVWSnV860WUXl34RMy7BempyGzN7pAbmXEA6bfvK0u32uTFKKVM0r0Yw1MTcFvp8iVLPD0+9gHQy+7rSf3eejp2HuFcsmldiEz0FzKXfSRw3qe08Xqd9dP6QKONnku4lG3NSb/RBtKtKt1ttdBJiYb2VI7brc7tc8IYotJzHUB0c+O+T3rTQuLKsZRqpzkTS7dZI4vo+qJndEGO8Ezecyjac6/ITN2KOWaULIT/aLdeUnqpdi7VW2+Kyc29FL3s7e3hi5LTSheWWpyWlH4XzmvWjniOiFN3YWDivWI92Wuk5ct2C0p3Jzl9YN66WI5IV/VyF86r1a17pH5UMC0pX/DwXVU524Ks5YgDZmL4zGz1w80p33Pj1pMvci+tc2cFIjmhH2dWVfuaVLuLjy9eTzgqOrqewv0vum/1KR4+2a6Dh5pXO7V9O+s4KRJPADuxNjtjFCCk/CltEzgfzSterSvdZQZeDoyyqxQguR1lXmBlI/9PSebZpbOe8bivt2bFK9YaK4eHe7NLNatLP3qGYLfL71RoMvB6Xu96J3TWt9LToQM5zm8YfxbHIESPZXXW/tovTSo+PqFxNeswZqjO/X09OvBgi9OcHw7llUukcv+di0rneqf99uXoKglMMwall7x/my0mlP5piVnv3fuZ+193xnpTYLz3SjejPLXpO6TtXbzXpfIUceJHmPsXAJsbI+aL7fvsppVsOX7uadJ9FvuT63PxsZAQ3UMxygLyWvsk6/luku40fb8ttolDFFb1ZQQ6/mRkv1iW9i1J6C/1aejAcvQPVmUt6FB2cn26JzDO4TsaLcWeaTbo7In04X08696XxTnrkmzGCHimmJpLuNaPi71f+KOkte5IK9OrS74ingPSfJd1oISD9Z0m/hPhB0o+/Ld3MMGUrSU68s9yUzXSO3suhW+Bh+Jj0oyz2snZqgpczd5iwpvRvmKfXpY/P0yeSfsgHOhliwtLS7cBSiR1aZFP30q+Bt3fXbK9hQ2Tr+4rSc+8dflXCO2l6pY+PIs5pF1xs4kmbXVB6z0JWRRdH+6B0w8VeoydeWlV84xaULnvX08vEzNn+HJOu+tfT1cSbKPLewvWkc/c1/Yts4SlJ+DHpunsF3069XSrw7VhQel4gHN3QuHO8jEk/O8cC+Uo/pXR+vG0LSn/ZXxlXyIoc60PSheldwvdzb4HW3I71pO/0wHYqOIp8v41JT52TNjf5jx24fmE96WLrG7/bsoM6ehCGpJ8s0/ZV3k8qnTOdX1B66HOgb4b5KRftl54fC7ovyvZZpXt6Jy4o3ZqedOvMTdslPUhD0rlWxvVMFtS0P1UOnPvWk84Xdb0DIXW/kHiMSLem7rMMKDmt9J0HmgtK/3Bg7GhgOGLCgPT8afp1pdTEx4886ngtKF2c9OpsgVDbOKCJOQaki+1VrFi+wriJpfNa/orShcrW286jLYsyyfZLl8SEtnM65j1SLH+wXVG6jc0DYI986FujKJnQLV0c1Mrw7sO5n/fwwDfkoj9gfD4ozhyFAUVMqBRlYrCd0oUnRrkiyEzOPFNLFzTzT5VlBXd3Om8ozkBtOOdDPZkU9k9/PCpLkHarnZUfIhXOv0/6ISv0SOcvj/1b9tzfkN5G3x7ebdIh34WfF6tpDrrYK6PUpd/4fJS3bpXartOJN+SRDBXOv0l6m6EzZ1z35lw9k3RO01WMFBU4H4+21lMbb8Xs0vlvYVHp3PUqKCcaODUsnbNLSR5cTC+dZ+ppVelCnKa117eNTNQkSVFiU2tP+QrSOVvZZaULqwvtPCh/jdMb3RN99QOkojv8LsQS0k/O7+tKf+NMT96NP0UvLvinRm9Jn24wVrbDCbGIdF4xVBNJ/xJSe6Ueo/Bj/9I/7Dy0PvrnJy5opSIRRZX0aQUAAPzX3h3UAACAQAx7YAD/anFBCNdamIABAAAAAAAAAAAAAAAAAAAAAAAAAADAmmoeK9HziB5I9EBXnx8AAAAAAAAAALBmAIZKmzWInxyOAAAAAElFTkSuQmCC",
+  "issuers": [
+    {
+      "id": "did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830",
+      "revocation": { "type": "NONE" },
+      "name": "SAMPLE CLINIC",
+      "identityProof": {
+        "type": "DNS-DID",
+        "location": "donotverify.testing.verify.gov.sg",
+        "key": "did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830#controller"
+      }
     }
+  ],
+  "$template": {
+    "name": "HEALTH_CERT",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://healthcert.renderer.moh.gov.sg/"
+  }
 }

--- a/test/fixtures/v2/pdt_lamp_wrapped.json
+++ b/test/fixtures/v2/pdt_lamp_wrapped.json
@@ -1,31 +1,31 @@
 {
   "version": "https://schema.openattestation.com/2.0/schema.json",
   "data": {
-    "id": "2604d319-1fca-40b9-8fe4-e07977492918:string:76caf3f9-5591-4ef1-b756-1cb47a76dede",
-    "version": "343d9653-f892-4ba1-9cdf-431bb10ca273:string:pdt-healthcert-v2.0",
-    "type": "9f5a3951-47ef-460c-aaed-e49496762c06:string:LAMP",
-    "validFrom": "7a1a0943-cebc-4bd3-b879-b2305c766dfe:string:2021-08-24T04:22:36.062Z",
-    "fhirVersion": "4e3a53bd-e855-4752-bef4-07d4b6ddc046:string:4.0.1",
+    "id": "9876c760-634b-4cd0-a65d-74b3a005c15c:string:76caf3f9-5591-4ef1-b756-1cb47a76dede",
+    "version": "06e0a316-7754-483d-bc81-77d3e6a70fae:string:pdt-healthcert-v2.0",
+    "type": "b33cd0d0-9622-4ed2-abf9-992ad8096269:string:LAMP",
+    "validFrom": "b0e8414a-2765-4619-9810-4e753fa2cd37:string:2021-08-24T04:22:36.062Z",
+    "fhirVersion": "ca39ce39-49d4-433e-8a7e-1f73fc490372:string:4.0.1",
     "fhirBundle": {
-      "resourceType": "0c95396c-ec8b-47fb-8eaa-a41dc0d42883:string:Bundle",
-      "type": "77ea7297-53c2-4267-9afb-8e1763a8a082:string:collection",
+      "resourceType": "1f71125f-f548-4022-8020-0f8539e8d44b:string:Bundle",
+      "type": "1123acff-51b6-4c98-8616-a5c326c4f53d:string:collection",
       "entry": [
         {
-          "fullUrl": "b9271663-6f2f-479a-90a3-9106a490ddb1:string:urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
+          "fullUrl": "b1d620c1-c159-4053-94a1-219c60f41a98:string:urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
           "resource": {
-            "resourceType": "eab568d0-7700-4ff2-9a42-d8b2c237f138:string:Patient",
+            "resourceType": "86ae46f7-90d9-414a-ba78-5ff933c90162:string:Patient",
             "extension": [
               {
-                "url": "deb69950-c276-4733-9dc4-3dcf4b23ea2d:string:http://hl7.org/fhir/StructureDefinition/patient-nationality",
+                "url": "b346cdd4-162b-4873-9d81-1f3dd1191b3a:string:http://hl7.org/fhir/StructureDefinition/patient-nationality",
                 "extension": [
                   {
-                    "url": "603ca57b-d83e-4cc8-ae42-8c6e7c6bede1:string:code",
+                    "url": "39a1c71e-7f71-490f-8f57-e1b563eeab6c:string:code",
                     "valueCodeableConcept": {
-                      "text": "5299a665-4a3a-47df-9da2-5029647b3e97:string:Patient Nationality",
+                      "text": "dc9365e0-f37c-4533-a6f5-e390c28bd8a0:string:Patient Nationality",
                       "coding": [
                         {
-                          "system": "b227508a-b953-4a37-8430-2883d7720a97:string:urn:iso:std:iso:3166",
-                          "code": "67ee84f1-b4fe-4b2a-b063-3241ca15742d:string:SG"
+                          "system": "1b6ed86a-d3ac-4a30-95aa-140c45cdfc3a:string:urn:iso:std:iso:3166",
+                          "code": "2928d3a3-240c-4c97-a206-55c92229edb5:string:SG"
                         }
                       ]
                     }
@@ -35,73 +35,58 @@
             ],
             "identifier": [
               {
-                "id": "2feb09b2-e1d3-4839-9b52-b7be2320293d:string:PPN",
+                "id": "62f1df76-3956-42b6-95b1-f4a2ffc3cf17:string:PPN",
                 "type": {
                   "coding": [
                     {
-                      "system": "54fb22b3-61c1-401c-b997-a553475b8482:string:http://terminology.hl7.org/CodeSystem/v2-0203",
-                      "code": "f5ac7acb-b8ba-4625-ae74-1be69b3ee389:string:PPN",
-                      "display": "b243efaa-d4b8-4e72-9607-d79feeb84391:string:Passport Number"
+                      "system": "1254db8b-8040-4b35-9941-53fef3608606:string:http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "157c361b-0e2b-42b2-8f13-feb46fc82b4d:string:PPN",
+                      "display": "8ed69d26-7f7a-4ec1-8556-5506ba229d2e:string:Passport Number"
                     }
                   ]
                 },
-                "value": "5a2ddd32-095b-485d-98a1-7982c5d04bff:string:E7831177G"
+                "value": "b9ea8317-e4c1-4ef2-bd11-15291a834fe5:string:E7831177G"
               },
               {
-                "id": "b1b89b06-b71b-409c-8c3b-b037bbf0784b:string:NRIC-FIN",
-                "value": "c51b3830-2073-47be-92c3-5aa65c5fbf9e:string:S3001470G"
+                "id": "4c676212-bad4-4cb9-8e14-6a3b1a556004:string:NRIC-FIN",
+                "value": "ed5e148a-9bd6-46cc-bdc2-a6a472e61af0:string:S3001470G"
               }
             ],
             "name": [
               {
-                "text": "acf27999-042f-4b13-b633-891eae758bdb:string:Tan Chen Chen"
+                "text": "730962d4-1033-4421-9ec3-c4ac0e326ea9:string:Tan Chen Chen"
               }
             ],
-            "gender": "deb34b46-b242-44c0-af0d-c505fd0256bb:string:female",
-            "birthDate": "91aecfbf-f5a9-4e4d-b773-4399c8746068:string:1990-01-15"
+            "gender": "90a1281a-1c33-4e6a-a5d9-496ffaedd904:string:female",
+            "birthDate": "8d901abd-3706-45d2-999f-a1957bebe381:string:1990-01-15"
           }
         },
         {
-          "fullUrl": "22b61a94-d245-4285-af2d-030b9b8cac9a:string:urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
+          "fullUrl": "be50e988-355d-450a-9282-62500022f2b7:string:urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
           "resource": {
-            "resourceType": "5223f375-d9f5-4222-a8f8-afe0f35804e2:string:Observation",
+            "resourceType": "0552f633-4115-4bcc-98d3-2325b26e131a:string:Observation",
             "specimen": {
-              "type": "61af5a2e-f122-4aca-8076-b922cfbf30b8:string:Specimen",
-              "reference": "86dd8e50-4939-43e2-bbac-88b449294b35:string:urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae"
+              "type": "6789b73b-19c1-4b0e-80e4-27f51c44bd8a:string:Specimen",
+              "reference": "6375eb5c-6154-4a68-b34e-1147acc05ce6:string:urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae"
             },
             "performer": [
               {
-                "type": "32ba5e8e-fb71-4c38-a021-5a64363b66f7:string:Practitioner",
-                "reference": "9e38e472-1516-4cb8-8210-b56ef87b38f2:string:urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+                "type": "20b7ca5d-f18b-4c36-b389-81500cb9a2f6:string:Practitioner",
+                "reference": "e785c593-c410-47e1-b18f-9a6141a7dbfc:string:urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
               },
               {
-                "id": "998b5739-ac64-41a5-a6df-d6383bd9d102:string:LHP",
-                "type": "af29100b-5118-4d90-8f6d-63b88f00e421:string:Organization",
-                "reference": "3d8717bb-4122-4781-941c-f57b7f01dfe5:string:urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1"
-              }
-            ],
-            "identifier": [
-              {
-                "id": "f29d9a7e-c32c-47fc-8565-5a9fac428bdc:string:ACSN",
-                "type": {
-                  "coding": [
-                    {
-                      "system": "c5275d16-e3f4-4e4b-8b1a-69028bce1f13:string:http://terminology.hl7.org/CodeSystem/v2-0203",
-                      "code": "c6f72ad1-c786-4db0-b095-8a6e4327d7d5:string:ACSN",
-                      "display": "322fd5d6-94b1-4f7d-aec6-35c1e0661ca3:string:Accession ID"
-                    }
-                  ]
-                },
-                "value": "725cf773-fb25-45d7-afe3-49b19171a3a6:string:123456789"
+                "id": "32d47f8c-599a-4a16-9fd3-68debda9b154:string:LHP",
+                "type": "b782fc9c-1458-4a21-83df-297067ba82a3:string:Organization",
+                "reference": "6c061663-e8c1-40aa-94dc-24bea58920b3:string:urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1"
               }
             ],
             "category": [
               {
                 "coding": [
                   {
-                    "system": "e7824b29-a73d-42f3-922c-ced0678ff72d:string:http://snomed.info/sct",
-                    "code": "47f4aa32-28d2-4d9b-9a93-4e737ad78bb3:string:840539006",
-                    "display": "5d2ba4f2-4043-42e5-8b77-94e3b18e3670:string:COVID-19"
+                    "system": "f2236dbb-357d-49b6-836c-0ce3721fcd80:string:http://snomed.info/sct",
+                    "code": "0b2a2be8-d8f5-4008-9709-266b12da9d3a:string:840539006",
+                    "display": "ad99b94e-bdbe-4ebd-bf37-7bb2d09b3976:string:COVID-19"
                   }
                 ]
               }
@@ -109,50 +94,50 @@
             "code": {
               "coding": [
                 {
-                  "system": "e1de83d5-eaad-40c5-9c74-d61837be3212:string:http://loinc.org",
-                  "code": "fa9d35c8-dea0-4baa-944a-fea279650665:string:96986-5",
-                  "display": "07fc903d-3a92-4dc3-9410-239f9d882975:string:SARS-CoV-2 (COVID-19) N gene [Presence] in Nose by NAA with non-probe detection"
+                  "system": "f1f0d34e-c0d7-42f6-a2f6-b9d4a607db3f:string:http://loinc.org",
+                  "code": "ca7bd2ae-f7e6-4616-aaf3-b416b552c9d0:string:96986-5",
+                  "display": "da913176-5559-4600-b49f-3645f14733c0:string:SARS-CoV-2 (COVID-19) N gene [Presence] in Nose by NAA with non-probe detection"
                 }
               ]
             },
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "6afc7da7-65a8-4cee-b9d2-62caccaa51ef:string:http://snomed.info/sct",
-                  "code": "f487baee-d57f-4ae2-95fb-8482e28b647c:string:260385009",
-                  "display": "63909ea1-48e1-40f6-8a33-2484ba3510c5:string:Negative"
+                  "system": "466f3c73-2e6a-4bbc-ae8e-516b66abedb4:string:http://snomed.info/sct",
+                  "code": "17a50839-84fd-492c-8fab-39f82e336b01:string:260385009",
+                  "display": "6e2ca45a-f643-4bd6-aa76-c669cb9bf4da:string:Negative"
                 }
               ]
             },
-            "effectiveDateTime": "22b3f947-cc3e-4250-8a6f-27944677a807:string:2020-09-28T06:15:00Z",
-            "status": "a00b5530-3943-4554-b424-de7d4e57cb36:string:final"
+            "effectiveDateTime": "e0f849d4-67e4-4b34-87ba-fb50a312dc02:string:2020-09-28T06:15:00Z",
+            "status": "c07b46c2-67e9-409b-a4cc-18a31eec0662:string:final"
           }
         },
         {
-          "fullUrl": "d6b3a65b-9cf1-4f14-89a0-f7f70175ced1:string:urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
+          "fullUrl": "0605ea7a-fa15-4adf-b854-ad20adfdd59c:string:urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
           "resource": {
-            "resourceType": "9d143299-db33-4d4a-a8df-ce9bb027f899:string:Specimen",
+            "resourceType": "2092348c-fdd0-43a4-8952-65f8cefb3b9e:string:Specimen",
             "type": {
               "coding": [
                 {
-                  "system": "9ed8d5d7-ef91-4543-9a12-809047bb79ba:string:http://snomed.info/sct",
-                  "code": "d66a5c0e-b16b-43fa-9c33-5405162dcb1d:string:697989009",
-                  "display": "de585212-0b59-4732-97e7-70b2bcfcdfb7:string:Anterior Nares swab"
+                  "system": "a5824113-d264-40db-9854-3c9dfd1480b9:string:http://snomed.info/sct",
+                  "code": "cad73f3d-8b3a-4a14-b492-fd304e930f26:string:697989009",
+                  "display": "96305230-88d6-454c-b8b5-a80976f85317:string:Anterior Nares swab"
                 }
               ]
             },
             "collection": {
-              "collectedDateTime": "48983c09-8bb9-4910-95cb-2cce5e6ff0d9:string:2020-09-27T06:15:00Z"
+              "collectedDateTime": "77749913-7b91-4898-88d8-a1811cd076bb:string:2020-09-27T06:15:00Z"
             }
           }
         },
         {
-          "fullUrl": "d7358389-f62d-4c3c-b050-0ccacc169b4b:string:urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
+          "fullUrl": "f9441304-99aa-48cd-9498-d9f2316dd2b1:string:urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
           "resource": {
-            "resourceType": "992d1318-3bfc-49ce-a021-3e3bc456b81b:string:Practitioner",
+            "resourceType": "bc05d497-13b2-46d3-9b94-cb6fa499f8ae:string:Practitioner",
             "name": [
               {
-                "text": "bdebd8eb-1425-4041-b0ea-865316b7f93b:string:Dr Michael Lim"
+                "text": "29f4309f-e2f0-4333-bb95-ca02e25f9fb4:string:Dr Michael Lim"
               }
             ],
             "qualification": [
@@ -160,38 +145,38 @@
                 "code": {
                   "coding": [
                     {
-                      "system": "3b26c6e2-1b7b-4288-97fa-2dd1bfa3a66c:string:http://terminology.hl7.org/CodeSystem/v2-0203",
-                      "code": "022fa744-b25e-4d04-b95e-1787ed1cd765:string:MCR",
-                      "display": "73187fc3-d83a-43f4-83bb-04ca92929909:string:Practitioner Medicare number"
+                      "system": "b4de1a36-7488-4384-ad64-70c337186dfa:string:http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "7245aab9-e4d4-4e15-bf4d-ec9546a22fda:string:MCR",
+                      "display": "2c4cd626-a1a6-42e2-a835-0dc105888414:string:Practitioner Medicare number"
                     }
                   ]
                 },
                 "identifier": [
                   {
-                    "id": "7deb3d63-4f43-47e8-8d94-ed3749631514:string:MCR",
-                    "value": "785e51b6-6ae3-46c3-8297-bd819eed65eb:string:123456"
+                    "id": "1ed3b7c8-9f94-4224-ad94-4f051355a85b:string:MCR",
+                    "value": "03475285-08f0-4bc2-9495-fcde609e2055:string:123456"
                   }
                 ],
                 "issuer": {
-                  "type": "69459e0b-c8fb-4951-967a-f3820c263cc4:string:Organization",
-                  "reference": "656621e1-99e5-45ea-8e0b-6e6ffdfabdcd:string:urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
+                  "type": "2f3e0a96-3e72-4c2e-9181-75cd565c144a:string:Organization",
+                  "reference": "1f6df6f7-ab60-4afd-a184-3bde57ca1ea8:string:urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
                 }
               }
             ]
           }
         },
         {
-          "fullUrl": "6df10c8d-0add-41a9-b10a-bef3f2a38d4b:string:urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
+          "fullUrl": "ab5b1362-29ac-442c-b6df-05b18adfc0d4:string:urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
           "resource": {
-            "resourceType": "70a0cfcb-5458-4e60-83b8-d8893a8b9c10:string:Organization",
-            "name": "8e92efb1-2a5f-421c-b31d-88fd9ef666c8:string:Ministry of Health (MOH)",
+            "resourceType": "7241920f-e0a7-4f01-a2ae-c5f6ffea2152:string:Organization",
+            "name": "c766a15c-50b2-42a4-87c3-24754f5233ac:string:Ministry of Health (MOH)",
             "type": [
               {
                 "coding": [
                   {
-                    "system": "93af8ebb-d620-4363-85f7-e294042733bc:string:http://terminology.hl7.org/CodeSystem/organization-type",
-                    "code": "d3b90f94-3620-453a-9079-22ff3ad6fe1f:string:govt",
-                    "display": "9dc7d3a0-6c1e-4008-88e2-fee89a6d4102:string:Government"
+                    "system": "5482651f-6eee-498c-aa68-048988247849:string:http://terminology.hl7.org/CodeSystem/organization-type",
+                    "code": "72d77c9a-1a0c-4d0f-9546-e621677c6dc4:string:govt",
+                    "display": "745512b2-e9e8-4bb6-9796-419367baea70:string:Government"
                   }
                 ]
               }
@@ -200,56 +185,56 @@
               {
                 "telecom": [
                   {
-                    "system": "9ae7f38c-fe77-46f4-b0ed-dad1a7018d20:string:url",
-                    "value": "8ccc2feb-749e-4c72-83ec-21503cb51b93:string:https://www.moh.gov.sg"
+                    "system": "57f9f4bc-38c7-4df7-88d1-66c0f4e38eb3:string:url",
+                    "value": "11833964-1dbb-4069-978f-6488eb99ae6e:string:https://www.moh.gov.sg"
                   },
                   {
-                    "system": "0f6faa32-4393-44b0-af29-7cfbf8263f45:string:phone",
-                    "value": "54a5c9dd-d280-4412-912f-4b40bdca7118:string:+6563259220"
+                    "system": "1dec9e9d-6510-461f-af11-b50cb799d993:string:phone",
+                    "value": "7ed7094c-5cca-41b5-af35-a67d2a3df058:string:+6563259220"
                   }
                 ],
                 "address": {
-                  "type": "44893f5c-022d-442d-baae-29a9d6e050a6:string:physical",
-                  "use": "fcf68f89-e502-484c-b8a7-c5c1a0966c20:string:work",
-                  "text": "40cf8f95-c692-44e2-9f29-02193e42955b:string:Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
+                  "type": "50f31476-b8df-4c78-8493-61235b2021b5:string:physical",
+                  "use": "62e4aba4-d297-45ce-9e0b-d3142c2680a6:string:work",
+                  "text": "1c9a9ade-bc43-4ce1-89da-7f87085ac444:string:Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
                 }
               }
             ]
           }
         },
         {
-          "fullUrl": "c4a5543c-f625-44d9-bedc-c0b15b72d5e1:string:urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
+          "fullUrl": "f5ce3334-5419-406d-8c6c-714d1d00e46c:string:urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
           "resource": {
-            "resourceType": "ad2dbf73-69a2-42c1-8025-0cd3c2da7c6f:string:Organization",
-            "name": "d8e812e2-ecc5-44b8-b79e-ffee7c4f103e:string:MacRitchie Medical Clinic",
+            "resourceType": "9ff1701a-bb41-4cfd-a6e4-2741a7249eed:string:Organization",
+            "name": "232ed149-7340-425d-a1c2-5622d252ec5b:string:MacRitchie Medical Clinic",
             "type": [
               {
                 "coding": [
                   {
-                    "system": "f15aa9ea-52c0-4187-8e0b-c61b6be0a84c:string:http://terminology.hl7.org/CodeSystem/organization-type",
-                    "code": "024fe380-1bde-48a1-ae34-50068f0f67dc:string:prov",
-                    "display": "70bd0dc4-6fe3-4155-afc9-c1fd58fa74bb:string:Healthcare Provider"
+                    "system": "4f2d9114-f615-4c5c-97f2-11f7492a33e8:string:http://terminology.hl7.org/CodeSystem/organization-type",
+                    "code": "0628c8ff-f838-40f9-a91a-02eb9e0311c7:string:prov",
+                    "display": "d325a142-1c90-401f-8c43-9142bf251a7a:string:Healthcare Provider"
                   }
                 ],
-                "text": "c2ef3ef6-32d9-4763-b31f-36f536195df1:string:Licensed Healthcare Provider"
+                "text": "8afe0ea9-3e8a-4c7c-8cc4-6704c83ebd4d:string:Licensed Healthcare Provider"
               }
             ],
             "contact": [
               {
                 "telecom": [
                   {
-                    "system": "73336ef1-ec81-40ba-9b57-5f2276aa9a4d:string:url",
-                    "value": "3dc82315-d6e0-4ca0-bfe4-1e8e1ccaa9d6:string:https://www.macritchieclinic.com.sg"
+                    "system": "a15fc1fe-ea2b-49eb-999d-07857f9affa2:string:url",
+                    "value": "da3885e5-c8b3-4b79-b7ae-53064b85fa2f:string:https://www.macritchieclinic.com.sg"
                   },
                   {
-                    "system": "882041c9-5609-4a78-ae8f-f53464dd3ee3:string:phone",
-                    "value": "78b8236b-c3f0-49b8-9d64-236025f19934:string:+6561234567"
+                    "system": "e65a1d37-2398-459f-8e74-898dc405462c:string:phone",
+                    "value": "a8a7ab59-7964-4683-9f1c-521512be5e1d:string:+6561234567"
                   }
                 ],
                 "address": {
-                  "type": "7445e34d-beb6-40fd-9ef5-0844f5bbd6c4:string:physical",
-                  "use": "048e4d52-3727-4d40-a51a-d785d98ae4c9:string:work",
-                  "text": "2768d2ed-8c5f-4786-9c93-3e730ceaa398:string:MacRitchie Hospital, Thomson Road, Singapore 123000"
+                  "type": "690066f3-95f9-4885-a2c2-2d5a988a4a1b:string:physical",
+                  "use": "190baaa3-bfee-4559-b667-d787f9703cf6:string:work",
+                  "text": "45501f19-0496-43ef-becd-dce2ce9ddedc:string:MacRitchie Hospital, Thomson Road, Singapore 123000"
                 }
               }
             ]
@@ -257,40 +242,40 @@
         }
       ]
     },
-    "logo": "e1aeca2a-25db-49b2-9af4-a05fad361c36:string:data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAADICAMAAAApx+PaAAAAM1BMVEUAAADMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzeCmiAAAAAEHRSTlMAQL+A7xAgn2DP3zBwr1CPEl+I/QAABwdJREFUeNrsnd122yoQRvkHISHN+z/tyUk9oTECQ1bTBc23byNs0B5GIDARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAk+Ik+Idx4g5N4B9GQ/rPA9J/IPfSgwL/MEEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwP5ZPoP5r7FJKAf7cufBihPNSkX5hlA9u+DsP7dX/JK1P2VPiSIoebErLwVh5Zx+8C1Y22YtP0Fpf6hdea+mq1Wlixfej6RcDxj09swXbbeBQpijug20aj/SE8bvo5hEuavAuSKpQfJxTG91gUrCV6jSQE0oPke4wuke705EqpLNWxtMtSk4jvXGld+tLlxvVMNnakD7mEndYTVWSnV860WUXl34RMy7BempyGzN7pAbmXEA6bfvK0u32uTFKKVM0r0Yw1MTcFvp8iVLPD0+9gHQy+7rSf3eejp2HuFcsmldiEz0FzKXfSRw3qe08Xqd9dP6QKONnku4lG3NSb/RBtKtKt1ttdBJiYb2VI7brc7tc8IYotJzHUB0c+O+T3rTQuLKsZRqpzkTS7dZI4vo+qJndEGO8Ezecyjac6/ITN2KOWaULIT/aLdeUnqpdi7VW2+Kyc29FL3s7e3hi5LTSheWWpyWlH4XzmvWjniOiFN3YWDivWI92Wuk5ct2C0p3Jzl9YN66WI5IV/VyF86r1a17pH5UMC0pX/DwXVU524Ks5YgDZmL4zGz1w80p33Pj1pMvci+tc2cFIjmhH2dWVfuaVLuLjy9eTzgqOrqewv0vum/1KR4+2a6Dh5pXO7V9O+s4KRJPADuxNjtjFCCk/CltEzgfzSterSvdZQZeDoyyqxQguR1lXmBlI/9PSebZpbOe8bivt2bFK9YaK4eHe7NLNatLP3qGYLfL71RoMvB6Xu96J3TWt9LToQM5zm8YfxbHIESPZXXW/tovTSo+PqFxNeswZqjO/X09OvBgi9OcHw7llUukcv+di0rneqf99uXoKglMMwall7x/my0mlP5piVnv3fuZ+193xnpTYLz3SjejPLXpO6TtXbzXpfIUceJHmPsXAJsbI+aL7fvsppVsOX7uadJ9FvuT63PxsZAQ3UMxygLyWvsk6/luku40fb8ttolDFFb1ZQQ6/mRkv1iW9i1J6C/1aejAcvQPVmUt6FB2cn26JzDO4TsaLcWeaTbo7In04X08696XxTnrkmzGCHimmJpLuNaPi71f+KOkte5IK9OrS74ingPSfJd1oISD9Z0m/hPhB0o+/Ld3MMGUrSU68s9yUzXSO3suhW+Bh+Jj0oyz2snZqgpczd5iwpvRvmKfXpY/P0yeSfsgHOhliwtLS7cBSiR1aZFP30q+Bt3fXbK9hQ2Tr+4rSc+8dflXCO2l6pY+PIs5pF1xs4kmbXVB6z0JWRRdH+6B0w8VeoydeWlV84xaULnvX08vEzNn+HJOu+tfT1cSbKPLewvWkc/c1/Yts4SlJ+DHpunsF3069XSrw7VhQel4gHN3QuHO8jEk/O8cC+Uo/pXR+vG0LSn/ZXxlXyIoc60PSheldwvdzb4HW3I71pO/0wHYqOIp8v41JT52TNjf5jx24fmE96WLrG7/bsoM6ehCGpJ8s0/ZV3k8qnTOdX1B66HOgb4b5KRftl54fC7ovyvZZpXt6Jy4o3ZqedOvMTdslPUhD0rlWxvVMFtS0P1UOnPvWk84Xdb0DIXW/kHiMSLem7rMMKDmt9J0HmgtK/3Bg7GhgOGLCgPT8afp1pdTEx4886ngtKF2c9OpsgVDbOKCJOQaki+1VrFi+wriJpfNa/orShcrW286jLYsyyfZLl8SEtnM65j1SLH+wXVG6jc0DYI986FujKJnQLV0c1Mrw7sO5n/fwwDfkoj9gfD4ozhyFAUVMqBRlYrCd0oUnRrkiyEzOPFNLFzTzT5VlBXd3Om8ozkBtOOdDPZkU9k9/PCpLkHarnZUfIhXOv0/6ISv0SOcvj/1b9tzfkN5G3x7ebdIh34WfF6tpDrrYK6PUpd/4fJS3bpXartOJN+SRDBXOv0l6m6EzZ1z35lw9k3RO01WMFBU4H4+21lMbb8Xs0vlvYVHp3PUqKCcaODUsnbNLSR5cTC+dZ+ppVelCnKa117eNTNQkSVFiU2tP+QrSOVvZZaULqwvtPCh/jdMb3RN99QOkojv8LsQS0k/O7+tKf+NMT96NP0UvLvinRm9Jn24wVrbDCbGIdF4xVBNJ/xJSe6Ueo/Bj/9I/7Dy0PvrnJy5opSIRRZX0aQUAAPzX3h3UAACAQAx7YAD/anFBCNdamIABAAAAAAAAAAAAAAAAAAAAAAAAAADAmmoeK9HziB5I9EBXnx8AAAAAAAAAALBmAIZKmzWInxyOAAAAAElFTkSuQmCC",
+    "logo": "6165d1d1-c044-4668-9739-9a8af29bd7a8:string:data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAADICAMAAAApx+PaAAAAM1BMVEUAAADMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzeCmiAAAAAEHRSTlMAQL+A7xAgn2DP3zBwr1CPEl+I/QAABwdJREFUeNrsnd122yoQRvkHISHN+z/tyUk9oTECQ1bTBc23byNs0B5GIDARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAk+Ik+Idx4g5N4B9GQ/rPA9J/IPfSgwL/MEEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwP5ZPoP5r7FJKAf7cufBihPNSkX5hlA9u+DsP7dX/JK1P2VPiSIoebErLwVh5Zx+8C1Y22YtP0Fpf6hdea+mq1Wlixfej6RcDxj09swXbbeBQpijug20aj/SE8bvo5hEuavAuSKpQfJxTG91gUrCV6jSQE0oPke4wuke705EqpLNWxtMtSk4jvXGld+tLlxvVMNnakD7mEndYTVWSnV860WUXl34RMy7BempyGzN7pAbmXEA6bfvK0u32uTFKKVM0r0Yw1MTcFvp8iVLPD0+9gHQy+7rSf3eejp2HuFcsmldiEz0FzKXfSRw3qe08Xqd9dP6QKONnku4lG3NSb/RBtKtKt1ttdBJiYb2VI7brc7tc8IYotJzHUB0c+O+T3rTQuLKsZRqpzkTS7dZI4vo+qJndEGO8Ezecyjac6/ITN2KOWaULIT/aLdeUnqpdi7VW2+Kyc29FL3s7e3hi5LTSheWWpyWlH4XzmvWjniOiFN3YWDivWI92Wuk5ct2C0p3Jzl9YN66WI5IV/VyF86r1a17pH5UMC0pX/DwXVU524Ks5YgDZmL4zGz1w80p33Pj1pMvci+tc2cFIjmhH2dWVfuaVLuLjy9eTzgqOrqewv0vum/1KR4+2a6Dh5pXO7V9O+s4KRJPADuxNjtjFCCk/CltEzgfzSterSvdZQZeDoyyqxQguR1lXmBlI/9PSebZpbOe8bivt2bFK9YaK4eHe7NLNatLP3qGYLfL71RoMvB6Xu96J3TWt9LToQM5zm8YfxbHIESPZXXW/tovTSo+PqFxNeswZqjO/X09OvBgi9OcHw7llUukcv+di0rneqf99uXoKglMMwall7x/my0mlP5piVnv3fuZ+193xnpTYLz3SjejPLXpO6TtXbzXpfIUceJHmPsXAJsbI+aL7fvsppVsOX7uadJ9FvuT63PxsZAQ3UMxygLyWvsk6/luku40fb8ttolDFFb1ZQQ6/mRkv1iW9i1J6C/1aejAcvQPVmUt6FB2cn26JzDO4TsaLcWeaTbo7In04X08696XxTnrkmzGCHimmJpLuNaPi71f+KOkte5IK9OrS74ingPSfJd1oISD9Z0m/hPhB0o+/Ld3MMGUrSU68s9yUzXSO3suhW+Bh+Jj0oyz2snZqgpczd5iwpvRvmKfXpY/P0yeSfsgHOhliwtLS7cBSiR1aZFP30q+Bt3fXbK9hQ2Tr+4rSc+8dflXCO2l6pY+PIs5pF1xs4kmbXVB6z0JWRRdH+6B0w8VeoydeWlV84xaULnvX08vEzNn+HJOu+tfT1cSbKPLewvWkc/c1/Yts4SlJ+DHpunsF3069XSrw7VhQel4gHN3QuHO8jEk/O8cC+Uo/pXR+vG0LSn/ZXxlXyIoc60PSheldwvdzb4HW3I71pO/0wHYqOIp8v41JT52TNjf5jx24fmE96WLrG7/bsoM6ehCGpJ8s0/ZV3k8qnTOdX1B66HOgb4b5KRftl54fC7ovyvZZpXt6Jy4o3ZqedOvMTdslPUhD0rlWxvVMFtS0P1UOnPvWk84Xdb0DIXW/kHiMSLem7rMMKDmt9J0HmgtK/3Bg7GhgOGLCgPT8afp1pdTEx4886ngtKF2c9OpsgVDbOKCJOQaki+1VrFi+wriJpfNa/orShcrW286jLYsyyfZLl8SEtnM65j1SLH+wXVG6jc0DYI986FujKJnQLV0c1Mrw7sO5n/fwwDfkoj9gfD4ozhyFAUVMqBRlYrCd0oUnRrkiyEzOPFNLFzTzT5VlBXd3Om8ozkBtOOdDPZkU9k9/PCpLkHarnZUfIhXOv0/6ISv0SOcvj/1b9tzfkN5G3x7ebdIh34WfF6tpDrrYK6PUpd/4fJS3bpXartOJN+SRDBXOv0l6m6EzZ1z35lw9k3RO01WMFBU4H4+21lMbb8Xs0vlvYVHp3PUqKCcaODUsnbNLSR5cTC+dZ+ppVelCnKa117eNTNQkSVFiU2tP+QrSOVvZZaULqwvtPCh/jdMb3RN99QOkojv8LsQS0k/O7+tKf+NMT96NP0UvLvinRm9Jn24wVrbDCbGIdF4xVBNJ/xJSe6Ueo/Bj/9I/7Dy0PvrnJy5opSIRRZX0aQUAAPzX3h3UAACAQAx7YAD/anFBCNdamIABAAAAAAAAAAAAAAAAAAAAAAAAAADAmmoeK9HziB5I9EBXnx8AAAAAAAAAALBmAIZKmzWInxyOAAAAAElFTkSuQmCC",
     "issuers": [
       {
-        "id": "f428c64d-3a50-4589-9c35-6d05a37bc16e:string:did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830",
+        "id": "04ed9a13-f21d-4b00-b20b-f432abf55d5c:string:did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830",
         "revocation": {
-          "type": "f302f1ef-dade-43e8-a6d4-aadb5d775b1b:string:NONE"
+          "type": "dad93733-6fd6-4e0e-829e-acf013bb1bef:string:NONE"
         },
-        "name": "3ac0b4f6-3037-4166-9937-04cbdd1a5c72:string:SAMPLE CLINIC",
+        "name": "459d9d34-0f7e-4400-b324-083235f0d88d:string:SAMPLE CLINIC",
         "identityProof": {
-          "type": "417bf576-2bae-4cfc-859f-e172cc886de7:string:DNS-DID",
-          "location": "01f6ca0c-43a7-4529-a288-fa134f5f2048:string:donotverify.testing.verify.gov.sg",
-          "key": "515a02cd-9e02-48c0-951e-3350b6565882:string:did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830#controller"
+          "type": "cf45ed1b-8dde-45a7-a4ab-0b001de587ca:string:DNS-DID",
+          "location": "ec0745c8-7bb8-4694-8985-3089481bab0b:string:donotverify.testing.verify.gov.sg",
+          "key": "644639ad-dd31-4cc3-861f-206028ce2e84:string:did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830#controller"
         }
       }
     ],
     "$template": {
-      "name": "d87ebd4c-acd4-4390-8789-375da482c293:string:HEALTH_CERT",
-      "type": "0236f249-255f-4353-b865-5e2a15340912:string:EMBEDDED_RENDERER",
-      "url": "bab71d13-1f4b-40bb-a976-6579debb044d:string:https://healthcert.renderer.moh.gov.sg/"
+      "name": "438ed292-ac68-473d-8381-e1e73a7e25b7:string:HEALTH_CERT",
+      "type": "0d4c6f05-5a07-4e18-af31-6352e050ec88:string:EMBEDDED_RENDERER",
+      "url": "1f612f7d-6c2a-4a9b-99bf-8b884abb3533:string:https://healthcert.renderer.moh.gov.sg/"
     }
   },
   "signature": {
     "type": "SHA3MerkleProof",
-    "targetHash": "c34fa9ec32aa9c7aa4b18c76bf7b7b2b635c3d5543ed7655910fab63e4e45b11",
+    "targetHash": "14ba4d3d1d50cf148b9172462aca6bf48738221c76ccf8a0baaa9844d7639218",
     "proof": [],
-    "merkleRoot": "c34fa9ec32aa9c7aa4b18c76bf7b7b2b635c3d5543ed7655910fab63e4e45b11"
+    "merkleRoot": "14ba4d3d1d50cf148b9172462aca6bf48738221c76ccf8a0baaa9844d7639218"
   },
   "proof": [
     {
       "type": "OpenAttestationSignature2018",
-      "created": "2022-06-07T03:44:43.200Z",
+      "created": "2022-06-27T03:08:26.791Z",
       "proofPurpose": "assertionMethod",
       "verificationMethod": "did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830#controller",
-      "signature": "0x076ae2d9717fa9d146afd73dce6b907136a60732aaff12e920fa67b54bd887b3113fd04ab9dc30c792871e3d306488528c2f22627e82382bcf6729615ede73631c"
+      "signature": "0xe689d1e77411def2c86dc6fd0a86e691b099f230fa49bd778cd4382dd539811312036022059227be2257bf1cdc7ad3f86af151c5f31e092f65ef9c770d1c832a1b"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

- ACSN field is now optional for `LAMP` HealthCerts
- Create `lampGroupedFhirKeys` from `commonGroupedFhirKeys` and removing the `"observations._.observation.acsn"` property
- Update LAMP samples