### PR TITLE
chore: use error code 404 for mismatched vault data

### DIFF
--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -13,6 +13,7 @@ export enum ErrorType {
   INVALID_PROVIDER = 400,
   INVALID_API_KEY = 400,
   INVALID_REVOCATION_REASON_CODE = 400,
+  VAULT_DATA_NOT_FOUND = 404,
 
   // 5xx internal server error
   NOTARISE_PDT_ERROR = 500,

--- a/src/functionHandlers/notarisePdt/v2/handler.ts
+++ b/src/functionHandlers/notarisePdt/v2/handler.ts
@@ -108,7 +108,7 @@ export const main: Handler = async (
           const clinicName =
             parsedFhirBundle.observations[0].organization.lhp.fullName;
           const vaultErr = new CodedError(
-            "VAULT_DATA_ERROR",
+            "VAULT_DATA_NOT_FOUND",
             "Date of birth and/or gender do not match existing records. Please try again with the correct values. If the problem persists, please submit supporting documents to support@notarise.gov.sg",
             `Clinic Name: ${clinicName}, Input dob: ${dob}, input gender: ${gender}`
           );


### PR DESCRIPTION
## What this PR does:
- return 404 error code when it is not able to find any matching records in vault data